### PR TITLE
sbt-docusaur v0.1.1

### DIFF
--- a/changelogs/0.1.1.md
+++ b/changelogs/0.1.1.md
@@ -1,0 +1,4 @@
+## [0.1.1](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone2%22) - 2020-06-30
+
+### Change
+* Changed: Setting Key `docusaurAlgoliaConfigFileName` to `docusaurAlgoliaConfigFilename` (#21)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.1.0"
+  val ProjectVersion: String = "0.1.1"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-docusaur v0.1.1
## [0.1.1](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone2%22) - 2020-06-30

### Change
* Changed: Setting Key `docusaurAlgoliaConfigFileName` to `docusaurAlgoliaConfigFilename` (#21)
