### PR TITLE
Close #31 - Support GitHub Enterprise

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val root = (project in file("."))
       ) ++ hedgehogLibs
   , testFrameworks ++= Seq(TestFramework("hedgehog.sbt.Framework"))
 
-  , addSbtPlugin("io.kevinlee" % "sbt-github-pages" % "0.1.3")
+  , addSbtPlugin("io.kevinlee" % "sbt-github-pages" % "0.2.0")
 
   /* GitHub Release { */
   , artifactsRequiredForGitHubRelease := false


### PR DESCRIPTION
# Close #31 - Support GitHub Enterprise
* It's done by upgrading sbt-github-pages from 0.1.3 to 0.2.0