### PR TITLE
sbt-docusaur v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,23 @@
+## [0.2.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone6%22) - 2020-09-19
+
+### Done
+* Support GitHub Enterprise (#31)
+  * It's done by upgrading `sbt-github-pages` from `0.1.3` to `0.2.0`.
+* Add Google Analytics support (#50)
+  ```scala
+  // The name of Google Analytics config file 
+  // (default: sys.env.getOrElse("GA_CONFIG_FILENAME", "google-analytics.config.json") )
+  docusaurGoogleAnalyticsConfigFilename: SettingKey[String]
+  
+  // Google Analytics Tracking ID. If None, Google Analytics config with an empty object is created.
+  // (default: sys.env.get("GA_TRACKING_ID") )
+  docusaurGoogleAnalyticsTrackingId: SettingKey[Option[String]]
+  
+  // Google Analytics option to anonymize IP.
+  // If None, the Google Analytics config will not have the `anonymizeIP` field. 
+  // (default: sys.env.get("GA_ANONYMIZE_IP") )
+  docusaurGoogleAnalyticsAnonymizeIp: SettingKey[Option[Boolean]]
+  
+  // Generate the Google Analytics config file at docusaurDir.value
+  docusaurGenerateGoogleAnalyticsConfigFile: TaskKey[Unit]
+  ```

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.1.4"
+  val ProjectVersion: String = "0.2.0"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-docusaur v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone6%22) - 2020-09-19

### Done
* Support GitHub Enterprise (#31)
  * It's done by upgrading `sbt-github-pages` from `0.1.3` to `0.2.0`.
* Add Google Analytics support (#50)
  ```scala
  // The name of Google Analytics config file 
  // (default: sys.env.getOrElse("GA_CONFIG_FILENAME", "google-analytics.config.json") )
  docusaurGoogleAnalyticsConfigFilename: SettingKey[String]
  
  // Google Analytics Tracking ID. If None, Google Analytics config with an empty object is created.
  // (default: sys.env.get("GA_TRACKING_ID") )
  docusaurGoogleAnalyticsTrackingId: SettingKey[Option[String]]
  
  // Google Analytics option to anonymize IP.
  // If None, the Google Analytics config will not have the `anonymizeIP` field. 
  // (default: sys.env.get("GA_ANONYMIZE_IP") )
  docusaurGoogleAnalyticsAnonymizeIp: SettingKey[Option[Boolean]]
  
  // Generate the Google Analytics config file at docusaurDir.value
  docusaurGenerateGoogleAnalyticsConfigFile: TaskKey[Unit]
  ```
