### PR TITLE
sbt-docusaur v0.2.1

### DIFF
--- a/changelogs/0.2.1.md
+++ b/changelogs/0.2.1.md
@@ -1,0 +1,4 @@
+## [0.2.1](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2020-09-20
+
+### Fixed
+* Doc site build fails when a Google Analytics config property has an empty String values (#58)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.2.0"
+  val ProjectVersion: String = "0.2.1"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-docusaur v0.2.1
## [0.2.1](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2020-09-20

### Fixed
* Doc site build fails when a Google Analytics config property has an empty String values (#58)
