### PR TITLE
sbt-docusaur v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,10 @@
+## [0.4.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone9%22) - 2021-02-20
+
+### Done
+* Upgrade libraries and sbt (#71)
+  * `sbt-github-pages`: `0.3.0` => `0.4.0`
+  * `sbt-devoops`: `1.0.3` => `2.0.0` - Changed: GitHub Actions config accordingly
+  * `cats`: `2.2.0` => `2.4.2`
+  * `cats-effect`: `2.2.0` => `2.3.3`
+  * `github4s`: `0.25.0` => `0.28.2`
+  * `http4s`: `0.21.6` => `0.21.19`

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.3.0"
+  val ProjectVersion: String = "0.4.0"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-docusaur v0.4.0
## [0.4.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone9%22) - 2021-02-20

### Done
* Upgrade libraries and sbt (#71)
  * `sbt-github-pages`: `0.3.0` => `0.4.0`
  * `sbt-devoops`: `1.0.3` => `2.0.0` - Changed: GitHub Actions config accordingly
  * `cats`: `2.2.0` => `2.4.2`
  * `cats-effect`: `2.2.0` => `2.3.3`
  * `github4s`: `0.25.0` => `0.28.2`
  * `http4s`: `0.21.6` => `0.21.19`
