### PR TITLE
Close #78 - Upgrade sbt plugin and libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.12.12", binary-version: "2.12", java-version: "adopt@1.8", sbt-version: "1.4.9" }
+          - { binary-version: "2.12", java-version: "adopt@1.8" }
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -32,7 +32,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
 
-    - name: Build for Scala ${{ matrix.scala.version }} and sbt ${{ matrix.scala.sbt-version }}
+    - name: Build
       run: |
         java -version
-        .github/workflows/sbt-build-simple.sh ${{ matrix.scala.version }} ${{ matrix.scala.sbt-version }}
+        .github/workflows/sbt-build-simple.sh

--- a/.github/workflows/sbt-build-simple.sh
+++ b/.github/workflows/sbt-build-simple.sh
@@ -2,27 +2,28 @@
 
 set -x
 
-if [ "$#" -ne 2 ]
-  then
-    echo "Scala version is missing. Please enter the Scala version."
-    echo "sbt-build-simple.sh 2.12.12 1.3.13"
-    exit 1
+echo "============================================"
+echo "Build projects (Simple)"
+echo "--------------------------------------------"
+echo ""
+CURRENT_BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+if [[ "$CURRENT_BRANCH_NAME" == "main" || "$CURRENT_BRANCH_NAME" == "release" ]]
+then
+  sbt \
+    -J-XX:MaxMetaspaceSize=1024m \
+    -J-Xmx2048m \
+    clean \
+    test \
+    packagedArtifacts
 else
-  SCALA_VERSION=$1
-  SBT_VERSION=$2
-  echo "============================================"
-  echo "Build projects (Simple)"
-  echo "--------------------------------------------"
-  echo ""
-  CURRENT_BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-  if [[ "$CURRENT_BRANCH_NAME" == "main" || "$CURRENT_BRANCH_NAME" == "release" ]]
-  then
-    sbt -J-Xmx2048m "; ++${SCALA_VERSION}!; ^^${SBT_VERSION}; clean; test; packagedArtifacts"
-  else
-    sbt -J-Xmx2048m "; ++${SCALA_VERSION}!; ^^${SBT_VERSION}; clean; test; package"
-  fi
-
-  echo "============================================"
-  echo "Building projects (Simple): Done"
-  echo "============================================"
+  sbt \
+    -J-XX:MaxMetaspaceSize=1024m \
+    -J-Xmx2048m \
+    clean \
+    test \
+    package
 fi
+
+echo "============================================"
+echo "Building projects (Simple): Done"
+echo "============================================"

--- a/build.sbt
+++ b/build.sbt
@@ -23,17 +23,15 @@ lazy val root = (project in file("."))
         s"git@github.com:${props.GitHubUsername}/${props.ProjectName}.git",
       ).some,
     startYear := 2020.some,
-    sbtVersion in Global := props.GlobalSbtVersion,
+    Global / sbtVersion := props.GlobalSbtVersion,
     crossSbtVersions := props.CrossSbtVersions,
     pluginCrossBuild / sbtVersion := "1.2.8",
-    addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.3" cross CrossVersion.full),
-    addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
     libraryDependencies ++= libs.all,
     testFrameworks ~= (fws => (TestFramework("hedgehog.sbt.Framework") +: fws).distinct),
-    addSbtPlugin("io.kevinlee"         % "sbt-github-pages"   % "0.4.0"),
+    addSbtPlugin("io.kevinlee"         % "sbt-github-pages"   % "0.5.0"),
     Compile / console / scalacOptions := scalacOptions.value diff List("-Ywarn-unused-import", "-Xfatal-warnings"),
-    wartremoverErrors in (Compile, compile) ++= commonWarts,
-    wartremoverErrors in (Test, compile) ++= commonWarts,
+    Compile / compile / wartremoverErrors ++= commonWarts,
+    Test / compile / wartremoverErrors ++= commonWarts,
     /* GitHub Release { */
     devOopsPackagedArtifacts := List.empty[String],
     /* } GitHub Release */
@@ -70,8 +68,16 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    val hedgehogVersion: String = "0.6.5"
-    val http4sVersion: String   = "0.21.20"
+    val hedgehogVersion: String = "0.6.7"
+
+    val catsVersion = "2.6.0"
+    val catsEffectVersion = "2.5.0"
+    val http4sVersion   = "0.21.22"
+    val github4sVersion = "0.28.4"
+
+    val effectieVersion = "1.10.0"
+    val loggerFVersion = "1.10.0"
+    val justSysprocessVersion = "0.6.0"
   }
 
 lazy val libs =
@@ -82,18 +88,18 @@ lazy val libs =
       "qa.hedgehog" %% "hedgehog-sbt"    % props.hedgehogVersion % Test,
     )
 
-    lazy val cats: ModuleID       = "org.typelevel" %% "cats-core"   % "2.4.2"
-    lazy val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "2.3.3"
-    lazy val github4s: ModuleID   = "com.47deg"     %% "github4s"    % "0.28.2"
+    lazy val cats: ModuleID       = "org.typelevel" %% "cats-core"   % props.catsVersion
+    lazy val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % props.catsEffectVersion
+    lazy val github4s: ModuleID   = "com.47deg"     %% "github4s"    % props.github4sVersion
 
     lazy val http4sDsl: ModuleID    = "org.http4s" %% "http4s-dsl"          % props.http4sVersion
     lazy val http4sClient: ModuleID = "org.http4s" %% "http4s-blaze-client" % props.http4sVersion
 
-    lazy val effectie: ModuleID          = "io.kevinlee" %% "effectie-cats-effect" % "1.9.0"
-    lazy val loggerFCatsEffect: ModuleID = "io.kevinlee" %% "logger-f-cats-effect" % "1.9.0"
-    lazy val loggerFSbtLogging: ModuleID = "io.kevinlee" %% "logger-f-sbt-logging" % "1.9.0"
+    lazy val effectie: ModuleID          = "io.kevinlee" %% "effectie-cats-effect" % props.effectieVersion
+    lazy val loggerFCatsEffect: ModuleID = "io.kevinlee" %% "logger-f-cats-effect" % props.loggerFVersion
+    lazy val loggerFSbtLogging: ModuleID = "io.kevinlee" %% "logger-f-sbt-logging" % props.loggerFVersion
 
-    lazy val justSysProcess: ModuleID = "io.kevinlee" %% "just-sysprocess" % "0.5.0"
+    lazy val justSysProcess: ModuleID = "io.kevinlee" %% "just-sysprocess" % props.justSysprocessVersion
 
     lazy val all: Seq[ModuleID] =
       List(

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,22 +4,6 @@ object ProjectInfo {
 
   val ProjectVersion: String = "0.4.0"
 
-  val commonScalacOptions: Seq[String] = Seq(
-      "-deprecation"
-    , "-unchecked"
-    , "-feature"
-    , "-Ywarn-value-discard"
-    , "-Yno-adapted-args"
-    , "-Xlint"
-    , "-Xfatal-warnings"
-    , "-Ywarn-dead-code"
-    , "-Ywarn-inaccessible"
-    , "-Ywarn-nullary-unit"
-    , "-Ywarn-nullary-override"
-    , "-language:higherKinds"
-    , "-encoding", "UTF-8"
-  )
-
   val commonWarts: Seq[Wart] =
     Warts.allBut(
         Wart.DefaultArguments

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,6 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
-
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
-
-addSbtPlugin("io.kevinlee" % "sbt-devoops" % "2.1.0")
-
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.4.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray"     % "0.5.6")
+addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "2.4.10")
+addSbtPlugin("io.kevinlee"       % "sbt-devoops"     % "2.3.0")
+addSbtPlugin("io.kevinlee"       % "sbt-docusaur"    % "0.4.0")


### PR DESCRIPTION
Close #78 - Upgrade sbt plugin and libraries
* sbt `1.4.9` => `1.5.1`
* sbt-devoops `2.1.0` => `2.3.0`
* sbt-github-pages `0.4.0` => `0.5.0`
* http4s `0.21.20` => `0.21.22`
* cats-core `2.4.2` => `2.6.0`
* cats-effect `2.3.3` => `2.5.0`
* github4s `0.28.2` => `0.28.4`
* effectie `1.9.0` => `1.10.0`
* logger-f `1.9.0` => `1.10.0`
