### PR TITLE
sbt-docusaur v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,15 @@
+## [0.5.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10) - 2021-05-04
+
+### Done
+* Upgrade sbt plugin and libraries (#78)
+  * sbt `1.4.9` => `1.5.1`
+  * sbt-devoops `2.1.0` => `2.3.0`
+  * sbt-github-pages `0.4.0` => `0.5.0`
+  * http4s `0.21.20` => `0.21.22`
+  * cats-core `2.4.2` => `2.6.0`
+  * cats-effect `2.3.3` => `2.5.0`
+  * github4s `0.28.2` => `0.28.4`
+  * effectie `1.9.0` => `1.10.0`
+  * logger-f `1.9.0` => `1.10.0`
+
+* Publish directly to Maven Central (#80)


### PR DESCRIPTION
# sbt-docusaur v0.5.0
## [0.5.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10) - 2021-05-04

### Done
* Upgrade sbt plugin and libraries (#78)
  * sbt `1.4.9` => `1.5.1`
  * sbt-devoops `2.1.0` => `2.3.0`
  * sbt-github-pages `0.4.0` => `0.5.0`
  * http4s `0.21.20` => `0.21.22`
  * cats-core `2.4.2` => `2.6.0`
  * cats-effect `2.3.3` => `2.5.0`
  * github4s `0.28.2` => `0.28.4`
  * effectie `1.9.0` => `1.10.0`
  * logger-f `1.9.0` => `1.10.0`

* Publish directly to Maven Central (#80)
