### PR TITLE
Close #87 - Upgrade sbt-github-pages to simplify gitHubPagesOrgName and gitHubPagesRepoName settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val root = (project in file("."))
         "Kevin Lee",
         "kevin.code@kevinlee.io",
         url(s"https://github.com/${props.GitHubUsername}"),
-      ),
+      )
     ),
     homepage := url(s"https://github.com/${props.GitHubUsername}/${props.ProjectName}").some,
     scmInfo :=
@@ -27,7 +27,7 @@ lazy val root = (project in file("."))
     pluginCrossBuild / sbtVersion := "1.2.8",
     libraryDependencies ++= libs.all,
     testFrameworks ~= (fws => (TestFramework("hedgehog.sbt.Framework") +: fws).distinct),
-    addSbtPlugin("io.kevinlee"         % "sbt-github-pages"   % "0.5.0"),
+    addSbtPlugin("io.kevinlee" % "sbt-github-pages" % "0.6.0"),
     Compile / console / scalacOptions := scalacOptions.value diff List("-Ywarn-unused-import", "-Xfatal-warnings"),
     Compile / compile / wartremoverErrors ++= commonWarts,
     Test / compile / wartremoverErrors ++= commonWarts,
@@ -41,8 +41,6 @@ lazy val root = (project in file("."))
     /* Docs { */
     docusaurDir := (ThisBuild / baseDirectory).value / "website",
     docusaurBuildDir := docusaurDir.value / "build",
-    gitHubPagesOrgName := props.GitHubUsername,
-    gitHubPagesRepoName := props.ProjectName,
     /* } Docs */
 
   )
@@ -63,13 +61,13 @@ lazy val props =
 
     val hedgehogVersion: String = "0.6.7"
 
-    val catsVersion = "2.6.0"
+    val catsVersion       = "2.6.0"
     val catsEffectVersion = "2.5.0"
-    val http4sVersion   = "0.21.22"
-    val github4sVersion = "0.28.4"
+    val http4sVersion     = "0.21.22"
+    val github4sVersion   = "0.28.4"
 
-    val effectieVersion = "1.10.0"
-    val loggerFVersion = "1.10.0"
+    val effectieVersion       = "1.10.0"
+    val loggerFVersion        = "1.10.0"
     val justSysprocessVersion = "0.6.0"
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.geirsson"    % "sbt-ci-release"  % "1.5.7")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
-addSbtPlugin("io.kevinlee"     % "sbt-devoops"     % "2.3.0")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.5.0")
+addSbtPlugin("com.geirsson"    % "sbt-ci-release"   % "1.5.7")
+addSbtPlugin("org.wartremover" % "sbt-wartremover"  % "2.4.10")
+addSbtPlugin("io.kevinlee"     % "sbt-devoops"      % "2.3.0")
+addSbtPlugin("io.kevinlee"     % "sbt-github-pages" % "0.6.0")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"     % "0.5.0")

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -84,15 +84,17 @@ docusaurBuildDir := docusaurDir.value / "build" / "some-project"
 ```
 
 
-### GitHub Org Name / Username *
+### GitHub Org Name / Username
 
 :::important
 This key must be set by the user of this plugin to publish the website to GitHub Pages.
+
+However, it is automatically done by `sbt-github-pages` so you don't need to set it up unless you want to set it otherwise.
 :::
 
-| Name                 | Value Type | Default    |
-| -------------------- | ---------- | ---------- |
-| `gitHubPagesOrgName` | `String`   |            |
+| Name                 | Value Type | Default                                  |
+| -------------------- | ---------- | ---------------------------------------- |
+| `gitHubPagesOrgName` | `String`   | Value obtained from calling `git remote` |
 
 The GitHub organization name (or username) (i.e.`OrgName` from `https://github.com/OrgName/RepoName`)
 
@@ -101,16 +103,22 @@ e.g.) If the repo is https://github.com/Kevin-Lee/sbt-docusaur
 gitHubPagesOrgName := "Kevin-Lee"
 ```
 
+:::note
+You don't need to set it up as `sbt-github-pages` does it automatically with the value from `git remote`.
+:::
 
-### GitHub Repo Name *
+
+### GitHub Repo Name
 
 :::important
 This key must be set by the user of this plugin to publish the website to GitHub Pages.
+
+However, it is automatically done by `sbt-github-pages` so you don't need to set it up unless you want to set it otherwise.
 :::
 
-| Name                  | Value Type | Default    |
-| --------------------- | ---------- | ---------- |
-| `gitHubPagesRepoName` | `String`  |            |
+| Name                  | Value Type | Default                                  |
+| --------------------- | ---------- | ---------------------------------------- |
+| `gitHubPagesRepoName` | `String`   | Value obtained from calling `git remote` |
 
 The GitHub project repository name (i.e. `RepoName` from `https://github.com/OrgName/RepoName`)
 
@@ -118,6 +126,11 @@ e.g.) If the repo is https://github.com/Kevin-Lee/sbt-docusaur
 ```scala
 gitHubPagesRepoName := "sbt-docusaur"
 ```
+
+:::note
+You don't need to set it up as `sbt-github-pages` does it automatically with the value from `git remote`.
+:::
+
 
 ## More Settings
 

--- a/website/docs/examples.md
+++ b/website/docs/examples.md
@@ -55,19 +55,16 @@ lazy val noPublish = Seq(
   publish := {},
   publishLocal := {},
   publishArtifact := false,
-  skip in publish := true
+  skip in publish := true,
 )
 
 lazy val docs = (project in file("generated-docs"))
   .enablePlugins(MdocPlugin, DocusaurPlugin)
   .settings(
-    name := "docs"
+    name := "docs",
 
-  , docusaurDir := (ThisBuild / baseDirectory).value / "website"
-  , docusaurBuildDir := docusaurDir.value / "build"
-
-  , gitHubPagesOrgName := "YOUR_USERNAME_OR_ORG_NAME"
-  , gitHubPagesRepoName := "REPO_NAME"
+    docusaurDir := (ThisBuild / baseDirectory).value / "website",
+    docusaurBuildDir := docusaurDir.value / "build",
   )
   .settings(noPublish) // This is optional to exclude this sub-project
                        // when sbt publish to upload the artifacts.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -32,8 +32,11 @@ lazy val root = (project in file("."))
     docusaurDir := (ThisBuild / baseDirectory).value / "website",
     docusaurBuildDir := docusaurDir.value / "build",
 
-    gitHubPagesOrgName := "github-username",
-    gitHubPagesRepoName := "project-name"
+    // Optional. It's automatically done by sbt-github-pages
+    // gitHubPagesOrgName := "github-username",
+    
+    // Optional. It's automatically done by sbt-github-pages
+    // gitHubPagesRepoName := "project-name"
   )
 ```
 


### PR DESCRIPTION
Close #87 - Upgrade `sbt-github-pages` to simplify `gitHubPagesOrgName` and `gitHubPagesRepoName` settings