### PR TITLE
sbt-docusaur v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,4 @@
+## [0.6.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11) - 2021-07-10
+
+### Done
+* Upgrade `sbt-github-pages` to simplify `gitHubPagesOrgName` and `gitHubPagesRepoName` settings (#87)


### PR DESCRIPTION
# sbt-docusaur v0.6.0
## [0.6.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11) - 2021-07-10

### Done
* Upgrade `sbt-github-pages` to simplify `gitHubPagesOrgName` and `gitHubPagesRepoName` settings (#87)
