### PR TITLE
Close #92 - Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,16 +59,16 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    val hedgehogVersion: String = "0.6.7"
+    val hedgehogVersion: String = "0.7.0"
 
-    val catsVersion       = "2.6.0"
-    val catsEffectVersion = "2.5.0"
-    val http4sVersion     = "0.21.22"
-    val github4sVersion   = "0.28.4"
+    val catsVersion       = "2.6.1"
+    val catsEffectVersion = "2.5.3"
+    val http4sVersion     = "0.21.27"
+    val github4sVersion   = "0.28.5"
 
-    val effectieVersion       = "1.10.0"
-    val loggerFVersion        = "1.10.0"
-    val justSysprocessVersion = "0.6.0"
+    val effectieVersion       = "1.15.0"
+    val loggerFVersion        = "1.15.0"
+    val justSysprocessVersion = "0.8.0"
   }
 
 lazy val libs =

--- a/src/main/scala/docusaur/Docusaur.scala
+++ b/src/main/scala/docusaur/Docusaur.scala
@@ -5,12 +5,12 @@ import java.nio.charset.Charset
 
 import cats._
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import docusaur.npm.Npm.NpmPath
 import docusaur.npm.{Npm, NpmCmd, NpmError}
 import effectie.cats.Effectful._
 import effectie.cats.EitherTSupport._
-import effectie.cats.{CanCatch, EffectConstructor}
+import effectie.cats.{CanCatch, Fx}
 import filef.{FileError2, FileF2}
 import loggerf.cats._
 import loggerf.syntax._
@@ -23,19 +23,19 @@ import sbt.{IO => SbtIo}
  */
 object Docusaur {
 
-  def deleteFilesIn[F[_]: EffectConstructor: CanCatch: Monad](
+  def deleteFilesIn[F[_]: Fx: CanCatch: Monad](
     what: String,
     file: File
   ): F[Either[FileError2, List[String]]] =
     FileF2.deleteAllIn[F](file)
 
-  def install[F[_]: EffectConstructor: CanCatch: LogF: Monad](
+  def install[F[_]: Fx: CanCatch: LogF: Monad](
     npmPath: Option[NpmPath],
     docusaurusDir: File
   ): F[Either[NpmError, Unit]] =
     runAndLogNpm("Docusaurus install", npmPath, docusaurusDir, NpmCmd.install)
 
-  def runBuild[F[_]: EffectConstructor: CanCatch: LogF: Monad](
+  def runBuild[F[_]: Fx: CanCatch: LogF: Monad](
     what: String,
     npmPath: Option[NpmPath],
     docusaurusDir: File
@@ -48,7 +48,7 @@ object Docusaur {
     )
 
 
-  def runAndLogNpm[F[_]: EffectConstructor: CanCatch: LogF: Monad](
+  def runAndLogNpm[F[_]: Fx: CanCatch: LogF: Monad](
     what: String,
     npmPath: Option[NpmPath],
     path: File,
@@ -68,13 +68,13 @@ object Docusaur {
   } yield ()).value
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  def logAndWriteFile[F[_]: EffectConstructor: LogF: Monad](
+  def logAndWriteFile[F[_]: Fx: LogF: Monad](
     theFile: File,
     content: String
   )(
     logMessage: String
   ): F[Unit] =
-    log(pureOf(logMessage))(info) *>
+    log(pureOf(logMessage))(info) >>
       effectOf(
         SbtIo.write(
           theFile,
@@ -84,7 +84,7 @@ object Docusaur {
         )
       )
 
-  def createAlgoliaConfig[F[_]: EffectConstructor: LogF: Monad](
+  def createAlgoliaConfig[F[_]: Fx: LogF: Monad](
     algoliaConfigPath: File,
     algoliaApiKey: Option[String],
     algoliaIndexName: Option[String]
@@ -150,7 +150,7 @@ object Docusaur {
         )
     }
 
-  def createGoogleAnalyticsConfig[F[_]: EffectConstructor: LogF: Monad](
+  def createGoogleAnalyticsConfig[F[_]: Fx: LogF: Monad](
     googleAnalyticsConfigPath: File,
     googleAnalyticsTrackingId: Option[String],
     googleAnalyticsAnonymizeIp: Option[Boolean]

--- a/src/main/scala/docusaur/npm/Npm.scala
+++ b/src/main/scala/docusaur/npm/Npm.scala
@@ -3,8 +3,8 @@ package docusaur.npm
 import java.io.File
 
 import cats._
-import cats.implicits._
-import effectie.cats.EffectConstructor
+import cats.syntax.all._
+import effectie.cats.Fx
 import effectie.cats.EitherTSupport._
 import just.sysprocess.{ProcessResult, SysProcess}
 
@@ -16,7 +16,7 @@ object Npm {
 
   final case class NpmPath(npmPath: File) extends AnyVal
 
-  def execute[F[_]: EffectConstructor: Monad, A](
+  def execute[F[_]: Fx: Monad, A](
     baseDir: Option[File],
     command: String,
     commands: String*
@@ -52,12 +52,12 @@ object Npm {
   private def npm(npmPath: Option[NpmPath]): String =
     npmPath.fold("npm")(_.npmPath.getCanonicalPath)
 
-  def version[F[_]: EffectConstructor: Monad](
+  def version[F[_]: Fx: Monad](
     npmPath: Option[NpmPath]
   ): F[Either[NpmError, String]] =
     execute(none, npm(npmPath), "--version")(_.mkString)
 
-  def run[F[_]: EffectConstructor: Monad](
+  def run[F[_]: Fx: Monad](
     npmPath: Option[NpmPath],
     baseDir: Option[File],
     npmCmd: NpmCmd

--- a/src/main/scala/filef/FileF2.scala
+++ b/src/main/scala/filef/FileF2.scala
@@ -4,11 +4,11 @@ import java.io.File
 
 import cats._
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import effectie.cats.Effectful._
 import effectie.cats.Catching._
 import effectie.cats.EitherTSupport._
-import effectie.cats.{CanCatch, EffectConstructor}
+import effectie.cats.{CanCatch, Fx}
 
 import scala.annotation.tailrec
 
@@ -17,7 +17,7 @@ import scala.annotation.tailrec
  * @since 2020-06-26
  */
 object FileF2 {
-  def deleteAllIn[F[_]: EffectConstructor: CanCatch: Monad](file: File): F[Either[FileError2, List[String]]] = {
+  def deleteAllIn[F[_]: Fx: CanCatch: Monad](file: File): F[Either[FileError2, List[String]]] = {
     @tailrec
     def listAllIn(files: List[File], acc: List[File]): List[File] =
       files match {


### PR DESCRIPTION
Close #92 - Upgrade libraries
- cats `2.6.0` => `2.6.1`
- cats-effect `2.5.0` => `2.5.3`
- http4s `0.21.22` => `0.21.27`
- github4s `0.28.4` => `0.28.5`
- effectie `1.10.0` => `1.15.0`
- logger-f `1.10.0` => `1.15.0`
- just-sysprocess `0.6.0` => `0.8.0`