### PR TITLE
sbt-docusaur v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,13 @@
+## [0.7.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2021-09-19
+
+### Done
+* Upgrade libraries (#92)
+  * `cats` `2.6.0` => `2.6.1`
+  * `cats-effect` `2.5.0` => `2.5.3`
+  * `http4s` `0.21.22` => `0.21.27`
+  * `github4s` `0.28.4` => `0.28.5`
+  * `effectie` `1.10.0` => `1.15.0`
+  * `logger-f` `1.10.0` => `1.15.0`
+  * `just-sysprocess` `0.6.0` => `0.8.0`
+* Add task to run `npm audit fix` (#93)
+* Upgrade `sbt-github-pages` to `0.7.0` (#96)


### PR DESCRIPTION
# sbt-docusaur v0.7.0
## [0.7.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2021-09-19

### Done
* Upgrade libraries (#92)
  * `cats` `2.6.0` => `2.6.1`
  * `cats-effect` `2.5.0` => `2.5.3`
  * `http4s` `0.21.22` => `0.21.27`
  * `github4s` `0.28.4` => `0.28.5`
  * `effectie` `1.10.0` => `1.15.0`
  * `logger-f` `1.10.0` => `1.15.0`
  * `just-sysprocess` `0.6.0` => `0.8.0`
* Add task to run `npm audit fix` (#93)
* Upgrade `sbt-github-pages` to `0.7.0` (#96)
