### PR TITLE
sbt-docusaur v0.8.0

### DIFF
--- a/changelogs/0.8.0.md
+++ b/changelogs/0.8.0.md
@@ -1,0 +1,5 @@
+## [0.8.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2021-09-30
+
+### Done
+* Upgrade `sbt-github-pages` to `0.8.0` (#103)
+* Upgrade `just-sysprocess` to `1.0.0` (#105)


### PR DESCRIPTION
# sbt-docusaur v0.8.0
## [0.8.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2021-09-30

### Done
* Upgrade `sbt-github-pages` to `0.8.0` (#103)
* Upgrade `just-sysprocess` to `1.0.0` (#105)
