### PR TITLE
sbt-docusaur v0.8.1

### DIFF
--- a/changelogs/0.8.1.md
+++ b/changelogs/0.8.1.md
@@ -1,0 +1,4 @@
+## [0.8.1](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14) - 2021-11-21
+
+### Fix
+* Upgrade `sbt-github-pages` to `0.8.1` (#110) to fix [Publish fails if the gh-pages branch does not already exist (#113)](/Kevin-Lee/sbt-github-pages/issues/113)


### PR DESCRIPTION
# sbt-docusaur v0.8.1
## [0.8.1](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14) - 2021-11-21

### Fix
* Upgrade `sbt-github-pages` to `0.8.1` (#110) to fix [Publish fails if the gh-pages branch does not already exist (#113)](/Kevin-Lee/sbt-github-pages/issues/113)
