### PR TITLE
Fix: sbt-ci-release had the wrong group ID for version 1.5.10

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.geirsson"    % "sbt-ci-release"  % "1.5.10")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.8.1")
 


### PR DESCRIPTION
Fix: sbt-ci-release had the wrong group ID for version 1.5.10