### PR TITLE
sbt-docusaur v0.9.0

### DIFF
--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,5 @@
+## [0.9.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15) - 2022-03-11
+
+### Done
+* Publish to `s01.oss.sonatype.org` (the new Maven central) (#120)
+* Add `ALGOLIA_APP_ID` for Algolia (#141)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.8.1")
 
-val sbtDevOopsVersion = "2.15.0"
+val sbtDevOopsVersion = "2.16.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# sbt-docusaur v0.9.0
## [0.9.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15) - 2022-03-11

### Done
* Publish to `s01.oss.sonatype.org` (the new Maven central) (#120)
* Add `ALGOLIA_APP_ID` for Algolia (#141)
