### PR TITLE
Close #151  - Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val root = (project in file("."))
     pluginCrossBuild / sbtVersion     := "1.2.8",
     libraryDependencies ++= libs.all,
     testFrameworks ~= (fws => (TestFramework("hedgehog.sbt.Framework") +: fws).distinct),
-    addSbtPlugin("io.kevinlee" % "sbt-github-pages" % "0.8.1"),
+    addSbtPlugin("io.kevinlee" % "sbt-github-pages" % "0.9.0"),
     Compile / console / scalacOptions := scalacOptions.value diff List("-Ywarn-unused-import", "-Xfatal-warnings"),
     Compile / compile / wartremoverErrors ++= commonWarts,
     Test / compile / wartremoverErrors ++= commonWarts,
@@ -75,16 +75,18 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val hedgehogVersion = "0.7.0"
+    final val hedgehogVersion = "0.8.0"
 
-    final val catsVersion       = "2.6.1"
-    final val catsEffectVersion = "2.5.3"
-    final val http4sVersion     = "0.21.27"
-    final val github4sVersion   = "0.28.5"
+    final val catsVersion       = "2.7.0"
+    final val catsEffectVersion = "3.3.5"
+    final val http4sVersion     = "0.23.11"
+    final val github4sVersion   = "0.31.0"
 
-    final val effectieVersion       = "1.15.0"
-    final val loggerFVersion        = "1.15.0"
+    final val effectieVersion       = "2.0.0-beta1"
+    final val loggerFVersion        = "2.0.0-beta1"
     final val justSysprocessVersion = "1.0.0"
+
+    final val ExtrasVersion = "0.13.0"
   }
 
 lazy val libs =
@@ -102,11 +104,13 @@ lazy val libs =
     lazy val http4sDsl: ModuleID    = "org.http4s" %% "http4s-dsl"          % props.http4sVersion
     lazy val http4sClient: ModuleID = "org.http4s" %% "http4s-blaze-client" % props.http4sVersion
 
-    lazy val effectie: ModuleID          = "io.kevinlee" %% "effectie-cats-effect" % props.effectieVersion
-    lazy val loggerFCatsEffect: ModuleID = "io.kevinlee" %% "logger-f-cats-effect" % props.loggerFVersion
-    lazy val loggerFSbtLogging: ModuleID = "io.kevinlee" %% "logger-f-sbt-logging" % props.loggerFVersion
+    lazy val effectie: ModuleID          = "io.kevinlee" %% "effectie-cats-effect3" % props.effectieVersion
+    lazy val loggerFCatsEffect: ModuleID = "io.kevinlee" %% "logger-f-cats" % props.loggerFVersion
+    lazy val loggerFSbtLogging: ModuleID = "io.kevinlee" %% "logger-f-sbt-logging"  % props.loggerFVersion
 
     lazy val justSysProcess: ModuleID = "io.kevinlee" %% "just-sysprocess" % props.justSysprocessVersion
+
+    lazy val extrasCats = "io.kevinlee" %% "extras-cats" % props.ExtrasVersion
 
     lazy val all: Seq[ModuleID] =
       List(
@@ -119,6 +123,7 @@ lazy val libs =
         loggerFCatsEffect,
         loggerFSbtLogging,
         justSysProcess,
+        extrasCats,
       ) ++ hedgehogLibs
   }
 

--- a/src/main/scala/docusaur/npm/Npm.scala
+++ b/src/main/scala/docusaur/npm/Npm.scala
@@ -1,12 +1,13 @@
 package docusaur.npm
 
-import java.io.File
 import cats._
 import cats.syntax.all._
-import effectie.cats.Fx
-import effectie.cats.Effectful._
-import effectie.cats.EitherTSupport._
+import effectie.core.Fx
+import effectie.syntax.all._
+import extras.cats.syntax.either._
 import just.sysprocess.{ProcessError, ProcessResult, SysProcess}
+
+import java.io.File
 
 /** @author Kevin Lee
   * @since 2020-06-23

--- a/src/main/scala/filef/FileF2.scala
+++ b/src/main/scala/filef/FileF2.scala
@@ -1,22 +1,21 @@
 package filef
 
-import java.io.File
 import cats._
 import cats.data.EitherT
 import cats.syntax.flatMap._
 import cats.syntax.traverse._
-import effectie.cats.Effectful._
-import effectie.cats.Catching._
-import effectie.cats.EitherTSupport._
-import effectie.cats.{CanCatch, Fx}
+import effectie.core.Fx
+import effectie.syntax.all._
+import extras.cats.syntax.all._
 
+import java.io.File
 import scala.annotation.tailrec
 
 /** @author Kevin Lee
   * @since 2020-06-26
   */
 object FileF2 {
-  def deleteAllIn[F[_]: Fx: CanCatch: Monad](file: File): F[Either[FileError2, List[String]]] = {
+  def deleteAllIn[F[_]: Fx: Monad](file: File): F[Either[FileError2, List[String]]] = {
     @tailrec
     def listAllIn(files: List[File], acc: List[File]): List[File] = files match {
       case Nil =>
@@ -34,9 +33,9 @@ object FileF2 {
       list         <- effectOf(file.listFiles.toList).rightT
       allFiles     <- effectOf(listAllIn(list, Nil)).rightT
       filesDeleted <- allFiles.traverse[ET, String] { file =>
-                        catchNonFatal[F](
-                          effectOf(file.delete()) >> effectOf(file.getCanonicalPath)
-                        )(throwable => FileError2.inDeletion(file, throwable)).eitherT
+                        (effectOf(file.delete()) >> effectOf(file.getCanonicalPath))
+                          .catchNonFatal(throwable => FileError2.inDeletion(file, throwable))
+                          .eitherT
                       }
 
     } yield filesDeleted).value

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1332,99 +1332,101 @@
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.17.tgz",
-      "integrity": "sha512-iNdW7CsmHNOgc4PxD9BFxa+MD8+i7ln7erOBkF3FSMMPnsKUeVqsR3rr31aLmLZRlTXMITSPLxlXwtBZa3KPCw==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.14.tgz",
+      "integrity": "sha512-dW95WbD+WE+35Ee1RYIS1QDcBhvUxUWuDmrWr1X0uH5ZHIeOmOnsGVjjn4FA8VN2MkF0uuWknmRakQmJk0KMZw==",
       "requires": {
-        "@babel/core": "^7.17.5",
-        "@babel/generator": "^7.17.3",
+        "@babel/core": "^7.16.0",
+        "@babel/generator": "^7.16.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.17.0",
-        "@babel/preset-env": "^7.16.11",
-        "@babel/preset-react": "^7.16.7",
-        "@babel/preset-typescript": "^7.16.7",
-        "@babel/runtime": "^7.17.2",
-        "@babel/runtime-corejs3": "^7.17.2",
-        "@babel/traverse": "^7.17.3",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
+        "@babel/plugin-transform-runtime": "^7.16.0",
+        "@babel/preset-env": "^7.16.4",
+        "@babel/preset-react": "^7.16.0",
+        "@babel/preset-typescript": "^7.16.0",
+        "@babel/runtime": "^7.16.3",
+        "@babel/runtime-corejs3": "^7.16.3",
+        "@babel/traverse": "^7.16.3",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.14",
+        "@docusaurus/logger": "2.0.0-beta.14",
+        "@docusaurus/mdx-loader": "2.0.0-beta.14",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.1",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.2",
-        "babel-loader": "^8.2.3",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@docusaurus/utils-common": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.0",
+        "@svgr/webpack": "^6.0.0",
+        "autoprefixer": "^10.3.5",
+        "babel-loader": "^8.2.2",
         "babel-plugin-dynamic-import-node": "2.3.0",
-        "boxen": "^6.2.1",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.2.4",
-        "cli-table3": "^0.6.1",
-        "combine-promises": "^1.1.0",
+        "boxen": "^5.0.1",
+        "chokidar": "^3.5.2",
+        "clean-css": "^5.1.5",
         "commander": "^5.1.0",
-        "copy-webpack-plugin": "^10.2.4",
-        "core-js": "^3.21.1",
-        "css-loader": "^6.6.0",
-        "css-minimizer-webpack-plugin": "^3.4.1",
-        "cssnano": "^5.0.17",
+        "copy-webpack-plugin": "^9.0.1",
+        "core-js": "^3.18.0",
+        "css-loader": "^5.1.1",
+        "css-minimizer-webpack-plugin": "^3.0.2",
+        "cssnano": "^5.0.8",
         "del": "^6.0.0",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
         "eta": "^1.12.3",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.1",
-        "html-minifier-terser": "^6.1.0",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.2",
+        "html-minifier-terser": "^6.0.2",
         "html-tags": "^3.1.0",
-        "html-webpack-plugin": "^5.5.0",
+        "html-webpack-plugin": "^5.4.0",
         "import-fresh": "^3.3.0",
         "is-root": "^2.1.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.5.3",
+        "lodash": "^4.17.20",
+        "mini-css-extract-plugin": "^1.6.0",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.7",
-        "postcss-loader": "^6.2.1",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.0",
-        "react-helmet-async": "^1.2.3",
+        "postcss": "^8.3.7",
+        "postcss-loader": "^6.1.1",
+        "prompts": "^2.4.1",
+        "react-dev-utils": "12.0.0-next.47",
+        "react-error-overlay": "^6.0.9",
+        "react-helmet": "^6.1.0",
         "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
         "react-router": "^5.2.0",
         "react-router-config": "^5.1.1",
         "react-router-dom": "^5.2.0",
         "remark-admonitions": "^1.2.1",
+        "resolve-pathname": "^3.0.0",
         "rtl-detect": "^1.0.4",
         "semver": "^7.3.4",
         "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.1",
+        "shelljs": "^0.8.4",
+        "strip-ansi": "^6.0.0",
+        "terser-webpack-plugin": "^5.2.4",
         "tslib": "^2.3.1",
         "update-notifier": "^5.1.0",
         "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.69.1",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.7.4",
+        "wait-on": "^6.0.0",
+        "webpack": "^5.61.0",
+        "webpack-bundle-analyzer": "^4.4.2",
+        "webpack-dev-server": "^4.5.0",
         "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
+        "webpackbar": "^5.0.0-3"
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.17.tgz",
-      "integrity": "sha512-DoBwtLjJ9IY9/lNMHIEdo90L4NDayvU28nLgtjR2Sc6aBIMEB/3a5Ndjehnp+jZAkwcDdNASA86EkZVUyz1O1A==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.14.tgz",
+      "integrity": "sha512-O5CebLXrytSQSpa0cgoMIUZ19gnLfCHhHPYqMfKxk0kvgR6g8b5AbsXxaMbgFNAqH690zPRsXmXb39BmXC7fMg==",
       "requires": {
-        "cssnano-preset-advanced": "^5.1.12",
-        "postcss": "^8.4.7",
-        "postcss-sort-media-queries": "^4.2.1"
+        "cssnano-preset-advanced": "^5.1.4",
+        "postcss": "^8.3.7",
+        "postcss-sort-media-queries": "^4.1.0"
       }
     },
     "@docusaurus/logger": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.17.tgz",
-      "integrity": "sha512-F9JDl06/VLg+ylsvnq9NpILSUeWtl0j4H2LtlLzX5gufEL4dGiCMlnUzYdHl7FSHSzYJ0A/R7vu0SYofsexC4w==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.14.tgz",
+      "integrity": "sha512-KNK8RgTGArXXlTUGhHUcYLJCI51gTMerSoebNXpTxAOBHFqjwJKv95LqVOy/uotoJZDUeEWR4vS/szGz4g7NaA==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.3.1"
@@ -1476,187 +1478,194 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.17.tgz",
-      "integrity": "sha512-AhJ3GWRmjQYCyINHE595pff5tn3Rt83oGpdev5UT9uvG9lPYPC8nEmh1LI6c0ogfw7YkNznzxWSW4hyyVbYQ3A==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.14.tgz",
+      "integrity": "sha512-lusTVTHc4WbNQY8bDM9zPQWZBIo70SnEyWzCqtznxpV7L3kjSoWEpBCHaYWE/lY2VhvayRsZtrqLwNs3KQgqXw==",
       "requires": {
-        "@babel/parser": "^7.17.3",
-        "@babel/traverse": "^7.17.3",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@mdx-js/mdx": "^1.6.22",
+        "@babel/parser": "^7.16.4",
+        "@babel/traverse": "^7.16.3",
+        "@docusaurus/logger": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@mdx-js/mdx": "^1.6.21",
+        "@mdx-js/react": "^1.6.21",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.1",
-        "image-size": "^1.0.1",
+        "fs-extra": "^10.0.0",
+        "gray-matter": "^4.0.3",
         "mdast-util-to-string": "^2.0.0",
         "remark-emoji": "^2.1.0",
         "stringify-object": "^3.3.0",
         "tslib": "^2.3.1",
         "unist-util-visit": "^2.0.2",
         "url-loader": "^4.1.1",
-        "webpack": "^5.69.1"
-      }
-    },
-    "@docusaurus/module-type-aliases": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.17.tgz",
-      "integrity": "sha512-Tu+8geC/wyygBudbSwvWIHEvt5RwyA7dEoE1JmPbgQtmqUxOZ9bgnfemwXpJW5mKuDiJASbN4of1DhbLqf4sPg==",
-      "requires": {
-        "@docusaurus/types": "2.0.0-beta.17",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*"
+        "webpack": "^5.61.0"
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.17.tgz",
-      "integrity": "sha512-gcX4UR+WKT4bhF8FICBQHy+ESS9iRMeaglSboTZbA/YHGax/3EuZtcPU3dU4E/HFJeZ866wgUdbLKpIpsZOidg==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.14.tgz",
+      "integrity": "sha512-MLDRNbQKxwBDsWADyBT/fES7F7xzEEGS8CsdTnm48l7yGSWL8GM3PT6YvjdqHxNxZw3RCRRPUAiJcjZwfOjd8w==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "cheerio": "^1.0.0-rc.10",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/logger": "2.0.0-beta.14",
+        "@docusaurus/mdx-loader": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
+        "escape-string-regexp": "^4.0.0",
         "feed": "^4.2.2",
-        "fs-extra": "^10.0.1",
-        "lodash": "^4.17.21",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.2",
+        "js-yaml": "^4.0.0",
+        "loader-utils": "^2.0.0",
+        "lodash": "^4.17.20",
         "reading-time": "^1.5.0",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1"
+        "webpack": "^5.61.0"
       },
       "dependencies": {
-        "cheerio": {
-          "version": "1.0.0-rc.10",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
-          "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
-          "requires": {
-            "cheerio-select": "^1.5.0",
-            "dom-serializer": "^1.3.2",
-            "domhandler": "^4.2.0",
-            "htmlparser2": "^6.1.0",
-            "parse5": "^6.0.1",
-            "parse5-htmlparser2-tree-adapter": "^6.0.1",
-            "tslib": "^2.2.0"
-          }
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
-        "htmlparser2": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.5.2",
-            "entities": "^2.0.0"
+            "argparse": "^2.0.1"
           }
         }
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.17.tgz",
-      "integrity": "sha512-YYrBpuRfTfE6NtENrpSHTJ7K7PZifn6j6hcuvdC0QKE+WD8pS+O2/Ws30yoyvHwLnAnfhvaderh1v9Kaa0/ANg==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.14.tgz",
+      "integrity": "sha512-pjAhfFevIkVl/t+6x9RVsE+6c+VN8Ru1uImTgXk5uVkp6yS1AxW7neEngsczZ1gSiENfTiYyhgWmTXK/uy03kw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/logger": "2.0.0-beta.14",
+        "@docusaurus/mdx-loader": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
         "combine-promises": "^1.1.0",
-        "fs-extra": "^10.0.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
+        "escape-string-regexp": "^4.0.0",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.2",
+        "import-fresh": "^3.2.2",
+        "js-yaml": "^4.0.0",
+        "loader-utils": "^2.0.0",
+        "lodash": "^4.17.20",
         "remark-admonitions": "^1.2.1",
+        "shelljs": "^0.8.4",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0",
-        "webpack": "^5.69.1"
+        "webpack": "^5.61.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.17.tgz",
-      "integrity": "sha512-d5x0mXTMJ44ojRQccmLyshYoamFOep2AnBe69osCDnwWMbD3Or3pnc2KMK9N7mVpQFnNFKbHNCLrX3Rv0uwEHA==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.14.tgz",
+      "integrity": "sha512-gGcMPG4e+K57cbBPf7IfV5lFCBdraXcpJeDqXlD8ArTeZrAe8Lx3SGz2lco25DgdRGqjMivab3BoT6Hkmo7vVA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/mdx-loader": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "fs-extra": "^10.0.1",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/mdx-loader": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
+        "globby": "^11.0.2",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.3.1",
-        "webpack": "^5.69.1"
+        "webpack": "^5.61.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.17.tgz",
-      "integrity": "sha512-p26fjYFRSC0esEmKo/kRrLVwXoFnzPCFDumwrImhPyqfVxbj+IKFaiXkayb2qHnyEGE/1KSDIgRF4CHt/pyhiw==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.14.tgz",
+      "integrity": "sha512-l0T26nZ9keyG2HrWwfwwHdqRzJg6cEJahyvKmnAOFfKieHPMxCJ9axBW+Ecy2PUMwJO7rILc6UObbhifNH7PnQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "fs-extra": "^10.0.1",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "fs-extra": "^10.0.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.17.tgz",
-      "integrity": "sha512-jvgYIhggYD1W2jymqQVAAyjPJUV1xMCn70bAzaCMxriureMWzhQ/kQMVQpop0ijTMvifOxaV9yTcL1VRXev++A==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.14.tgz",
+      "integrity": "sha512-fVtAwqK9iHjj32Dtg0j+T6ikD8yjTh5ruYru7rKYxld6LSSkU29Q0wp39qYxR390jn3rkrXLRCZ7qHT/Hs0zZg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.17.tgz",
-      "integrity": "sha512-1pnWHtIk1Jfeqwvr8PlcPE5SODWT1gW4TI+ptmJbJ296FjjyvL/pG0AcGEJmYLY/OQc3oz0VQ0W2ognw9jmFIw==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.14.tgz",
+      "integrity": "sha512-DcaNRvu0VLS/C6qRAG0QNWjnuP8dAdzH0NOfl86AxdK6dWOP5NlGD9QoIFKTa19PB8iTzM2XZn/hOCub4hR6MQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.17.tgz",
-      "integrity": "sha512-19/PaGCsap6cjUPZPGs87yV9e1hAIyd0CTSeVV6Caega8nmOKk20FTrQGFJjZPeX8jvD9QIXcdg6BJnPxcKkaQ==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.14.tgz",
+      "integrity": "sha512-ikSgz4VAttDB2uOrPa7fq/E/GKS5HAtKfD572kBj8RvppdlgFYwCLZ88ex5cnRFF//2ccaobYkU4QwDw2UKWMA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "fs-extra": "^10.0.1",
-        "sitemap": "^7.1.1",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@docusaurus/utils-common": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
+        "fs-extra": "^10.0.0",
+        "sitemap": "^7.0.0",
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.17.tgz",
-      "integrity": "sha512-7YUxPEgM09aZWr25/hpDEp1gPl+1KsCPV1ZTRW43sbQ9TinPm+9AKR3rHVDa8ea8MdiS7BpqCVyK+H/eiyQrUw==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.14.tgz",
+      "integrity": "sha512-43rHA6wM4FcbHLPiBpqY4VSUjUXOWvW/N4q0wvf1LMoPH25lUzIaldpjD3Unzq5+UCYCFES24ktl58QOh7PB2g==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
-        "@docusaurus/plugin-debug": "2.0.0-beta.17",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.17",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.17",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.17",
-        "@docusaurus/theme-classic": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.17"
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.14",
+        "@docusaurus/plugin-debug": "2.0.0-beta.14",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.14",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.14",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.14",
+        "@docusaurus/theme-classic": "2.0.0-beta.14",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.14"
       }
     },
     "@docusaurus/react-loadable": {
@@ -1669,136 +1678,122 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.17.tgz",
-      "integrity": "sha512-xfZ9kpgqo0lP9YO4rJj79wtiQJXU6ARo5wYy10IIwiWN+lg00scJHhkmNV431b05xIUjUr0cKeH9nqZmEsQRKg==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.14.tgz",
+      "integrity": "sha512-gAatNruzgPh1NdCcIJPkhBpZE4jmbO+nYwpk/scatYQWBkhOs/fcI9tieIaGZIqi60N6lAUYQkPH+qXtLxX7Iw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-translations": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-common": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "@mdx-js/react": "^1.6.22",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.14",
+        "@docusaurus/theme-common": "2.0.0-beta.14",
+        "@docusaurus/theme-translations": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
+        "@mdx-js/mdx": "^1.6.21",
+        "@mdx-js/react": "^1.6.21",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.0.1",
+        "globby": "^11.0.2",
         "infima": "0.2.0-alpha.37",
-        "lodash": "^4.17.21",
-        "postcss": "^8.4.7",
+        "lodash": "^4.17.20",
+        "postcss": "^8.3.7",
         "prism-react-renderer": "^1.2.1",
-        "prismjs": "^1.27.0",
+        "prismjs": "^1.23.0",
         "react-router-dom": "^5.2.0",
         "rtlcss": "^3.3.0"
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.17.tgz",
-      "integrity": "sha512-LJBDhx+Qexn1JHBqZbE4k+7lBaV1LgpE33enXf43ShB7ebhC91d5HLHhBwgt0pih4+elZU4rG+BG/roAmsNM0g==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.14.tgz",
+      "integrity": "sha512-hr/+rx9mszjMEbrR329WFSj1jl/VxglSggLWhXqswiA3Lh5rbbeQv2ExwpBl4JBG5HxvtHUYmwYOuOTMuvRYTQ==",
       "requires": {
-        "@docusaurus/module-type-aliases": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.17",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.14",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.14",
         "clsx": "^1.1.1",
+        "fs-extra": "^10.0.0",
         "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^1.3.1",
         "tslib": "^2.3.1",
         "utility-types": "^3.10.0"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.17.tgz",
-      "integrity": "sha512-W12XKM7QC5Jmrec359bJ7aDp5U8DNkCxjVKsMNIs8rDunBoI/N+R35ERJ0N7Bg9ONAWO6o7VkUERQsfGqdvr9w==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.14.tgz",
+      "integrity": "sha512-kTQl8vKXn8FAVVkCeN4XvU8PGWZTHToc+35F9GL06b4rv33zL9HaFIRX3nPM1NHC7I8qh+6gGeV0DRKGjO+j2g==",
       "requires": {
-        "@docsearch/react": "^3.0.0",
-        "@docusaurus/core": "2.0.0-beta.17",
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/theme-common": "2.0.0-beta.17",
-        "@docusaurus/theme-translations": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "@docusaurus/utils-validation": "2.0.0-beta.17",
-        "algoliasearch": "^4.12.1",
-        "algoliasearch-helper": "^3.7.0",
+        "@docsearch/react": "^3.0.0-alpha.39",
+        "@docusaurus/core": "2.0.0-beta.14",
+        "@docusaurus/logger": "2.0.0-beta.14",
+        "@docusaurus/theme-common": "2.0.0-beta.14",
+        "@docusaurus/theme-translations": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "@docusaurus/utils-validation": "2.0.0-beta.14",
+        "algoliasearch": "^4.10.5",
+        "algoliasearch-helper": "^3.5.5",
         "clsx": "^1.1.1",
         "eta": "^1.12.3",
-        "fs-extra": "^10.0.1",
-        "lodash": "^4.17.21",
-        "tslib": "^2.3.1",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "@docusaurus/theme-translations": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.17.tgz",
-      "integrity": "sha512-oxCX6khjZH3lgdRCL0DH06KkUM/kDr9+lzB35+vY8rpFeQruVgRdi8ekPqG3+Wr0U/N+LMhcYE5BmCb6D0Fv2A==",
-      "requires": {
-        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.20",
         "tslib": "^2.3.1"
       }
     },
-    "@docusaurus/types": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.17.tgz",
-      "integrity": "sha512-4o7TXu5sKlQpybfFFtsGUElBXwSpiXKsQyyWaRKj7DRBkvMtkDX6ITZNnZO9+EHfLbP/cfrokB8C/oO7mCQ5BQ==",
+    "@docusaurus/theme-translations": {
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-beta.14.tgz",
+      "integrity": "sha512-b67qJJIWc3A2tanYslDGpAUGfJ7oVAl+AdjGBYG3j3hYEUSyVUBzm8Y4iyCFEfW6BTx9pjqC/ECNO3iH2L3Ixg==",
       "requires": {
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "querystring": "0.2.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.69.1",
-        "webpack-merge": "^5.8.0"
-      },
-      "dependencies": {
-        "querystring": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-          "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
-        }
+        "fs-extra": "^10.0.0",
+        "tslib": "^2.3.1"
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.17.tgz",
-      "integrity": "sha512-yRKGdzSc5v6M/6GyQ4omkrAHCleevwKYiIrufCJgRbOtkhYE574d8mIjjirOuA/emcyLxjh+TLtqAA5TwhIryA==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.14.tgz",
+      "integrity": "sha512-7V+X70a+7UJHS7PeXS/BO2jz+zXaKhRlT7MUe5khu6i6n1oQA3Jqx1sfu78slemqEWe8u337jxal6uILcB0IWQ==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/logger": "2.0.0-beta.14",
+        "@mdx-js/runtime": "^1.6.22",
         "@svgr/webpack": "^6.0.0",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
-        "fs-extra": "^10.0.1",
+        "fs-extra": "^10.0.0",
         "github-slugger": "^1.4.0",
         "globby": "^11.0.4",
         "gray-matter": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.20",
         "micromatch": "^4.0.4",
+        "remark-mdx-remove-exports": "^1.6.22",
+        "remark-mdx-remove-imports": "^1.6.22",
         "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
         "tslib": "^2.3.1",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.69.1"
+        "url-loader": "^4.1.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.17.tgz",
-      "integrity": "sha512-90WCVdj6zYzs7neEIS594qfLO78cUL6EVK1CsRHJgVkkGjcYlCQ1NwkyO7bOb+nIAwdJrPJRc2FBSpuEGxPD3w==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.14.tgz",
+      "integrity": "sha512-hNWyy083Bm+6jEzsm05gFmEfwumXph0E46s2HrWkSM8tClrOVmu/C1Rm7kWYn561gXHhrATtyXr/u8bKXByFcQ==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.17.tgz",
-      "integrity": "sha512-5UjayUP16fDjgd52eSEhL7SlN9x60pIhyS+K7kt7RmpSLy42+4/bSr2pns2VlATmuaoNOO6iIFdB2jgSYJ6SGA==",
+      "version": "2.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.14.tgz",
+      "integrity": "sha512-ttDp/fXjbM6rTfP8XCmBKtNygfPg8cncp+rPsWHdSFjGmE7HkinilFTtaw0Zos/096TtxsQx3DgGQyPOl6prnA==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-beta.17",
-        "@docusaurus/utils": "2.0.0-beta.17",
-        "joi": "^17.6.0",
+        "@docusaurus/logger": "2.0.0-beta.14",
+        "@docusaurus/utils": "2.0.0-beta.14",
+        "joi": "^17.4.2",
         "tslib": "^2.3.1"
       }
     },
@@ -1902,6 +1897,16 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
+    },
+    "@mdx-js/runtime": {
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@mdx-js/runtime/-/runtime-1.6.22.tgz",
+      "integrity": "sha512-p17spaO2+55VLCuxXA3LVHC4phRx60NR2XMdZ+qgVU1lKvEX4y88dmFNOzGDCPLJ03IZyKrJ/rPWWRiBrd9JrQ==",
+      "requires": {
+        "@mdx-js/mdx": "1.6.22",
+        "@mdx-js/react": "1.6.22",
+        "buble-jsx-only": "^0.19.8"
+      }
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -2203,11 +2208,6 @@
         "@types/unist": "*"
       }
     },
-    "@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
-    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -2279,35 +2279,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "@types/react-router": {
-      "version": "5.1.18",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
-      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
-      "requires": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "@types/react-router-config": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.6.tgz",
-      "integrity": "sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==",
-      "requires": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
-      }
-    },
-    "@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "requires": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
-      }
-    },
     "@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
@@ -2357,9 +2328,9 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@types/ws": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
-      "integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "requires": {
         "@types/node": "*"
       }
@@ -2515,14 +2486,24 @@
       }
     },
     "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+    },
+    "acorn-dynamic-import": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -2620,18 +2601,6 @@
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "requires": {
         "string-width": "^4.1.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
       }
     },
     "ansi-html-community": {
@@ -2928,18 +2897,18 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boxen": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-6.2.1.tgz",
-      "integrity": "sha512-H4PEsJXfFI/Pt8sjDWbHlQPx4zL/bvSQjcilJmaulGt5mLDorHOHpmdXAJcBcmru7PhYSp/cDMWRko4ZUMFkSw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
       "requires": {
-        "ansi-align": "^3.0.1",
+        "ansi-align": "^3.0.0",
         "camelcase": "^6.2.0",
-        "chalk": "^4.1.2",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^5.0.1",
-        "type-fest": "^2.5.0",
-        "widest-line": "^4.0.1",
-        "wrap-ansi": "^8.0.1"
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3014,6 +2983,61 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
+      }
+    },
+    "buble-jsx-only": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/buble-jsx-only/-/buble-jsx-only-0.19.8.tgz",
+      "integrity": "sha512-7AW19pf7PrKFnGTEDzs6u9+JZqQwM1VnLS19OlqYDhXomtFFknnoQJAPHeg84RMFWAvOhYrG7harizJNwUKJsA==",
+      "requires": {
+        "acorn": "^6.1.1",
+        "acorn-dynamic-import": "^4.0.0",
+        "acorn-jsx": "^5.0.1",
+        "chalk": "^2.4.2",
+        "magic-string": "^0.25.3",
+        "minimist": "^1.2.0",
+        "regexpu-core": "^4.5.4"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+        },
+        "regenerate-unicode-properties": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
+          "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
+          "requires": {
+            "regenerate": "^1.4.2"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
+          "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
+          "requires": {
+            "regenerate": "^1.4.2",
+            "regenerate-unicode-properties": "^9.0.0",
+            "regjsgen": "^0.5.2",
+            "regjsparser": "^0.7.0",
+            "unicode-match-property-ecmascript": "^2.0.0",
+            "unicode-match-property-value-ecmascript": "^2.0.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+          "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
+        },
+        "regjsparser": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
+          "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
       }
     },
     "buffer-from": {
@@ -3110,9 +3134,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001314",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
-      "integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw=="
+      "version": "1.0.30001315",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001315.tgz",
+      "integrity": "sha512-5v7LFQU4Sb/qvkz7JcZkvtSH1Ko+1x2kgo3ocdBeMGZSOFpuE1kkm0kpTwLtWeFrw5qw08ulLxJjVIXIS8MkiQ=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -3221,18 +3245,6 @@
         }
       }
     },
-    "cheerio-select": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
-      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
-      "requires": {
-        "css-select": "^4.1.3",
-        "css-what": "^5.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0",
-        "domutils": "^2.7.0"
-      }
-    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -3279,30 +3291,9 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
-    },
-    "cli-table3": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
-      "requires": {
-        "colors": "1.4.0",
-        "string-width": "^4.2.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -3354,12 +3345,6 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "optional": true
     },
     "combine-promises": {
       "version": "1.1.0",
@@ -3480,42 +3465,18 @@
       "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q=="
     },
     "copy-webpack-plugin": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.4.tgz",
-      "integrity": "sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+      "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
       "requires": {
         "fast-glob": "^3.2.7",
         "glob-parent": "^6.0.1",
-        "globby": "^12.0.2",
+        "globby": "^11.0.3",
         "normalize-path": "^3.0.0",
-        "schema-utils": "^4.0.0",
+        "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.3"
-          }
-        },
-        "array-union": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-          "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw=="
-        },
         "glob-parent": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3523,40 +3484,6 @@
           "requires": {
             "is-glob": "^4.0.3"
           }
-        },
-        "globby": {
-          "version": "12.2.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
-          "integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
-          "requires": {
-            "array-union": "^3.0.1",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.7",
-            "ignore": "^5.1.9",
-            "merge2": "^1.4.1",
-            "slash": "^4.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "schema-utils": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "ajv": "^8.8.0",
-            "ajv-formats": "^2.1.1",
-            "ajv-keywords": "^5.0.0"
-          }
-        },
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
         }
       }
     },
@@ -3635,17 +3562,19 @@
       }
     },
     "css-loader": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
-      "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+      "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.7",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.15",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
         "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^3.0.0",
         "semver": "^7.3.5"
       }
     },
@@ -3743,62 +3672,62 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.3.tgz",
-      "integrity": "sha512-bdf+sY2w4XV+F5LOCEd7fWnSeMeKBO4lKgoAKVWZOSTR7CmWEk1UW/s9ibTMMnsTsinBmIdgZs755sAGa1eoXQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.4.tgz",
+      "integrity": "sha512-hbfhVZreEPyzl+NbvRsjNo54JOX80b+j6nqG2biLVLaZHJEiqGyMh4xDGHtwhUKd5p59mj2GlDqlUBwJUuIu5A==",
       "requires": {
-        "cssnano-preset-default": "^5.2.3",
+        "cssnano-preset-default": "^*",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.2.4.tgz",
-      "integrity": "sha512-jakbdAfyLI3zo3qGVwFFtiBA9uiCwzSmoGh5xkkmXsyPQkQSyamU1+GUdTH40FKXGs8M+NWErnX2EGM1hqIQKA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.2.5.tgz",
+      "integrity": "sha512-Zjq42GtsRN1gw1LcgY7PHsXlw/k65Ps3uc9cG8jKY1uNqux6eDqt6Fdc/vTWb/Z6ZhnDyecul8cdCHImbU6E5g==",
       "requires": {
         "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.3",
-        "postcss-discard-unused": "^5.1.0",
-        "postcss-merge-idents": "^5.1.0",
-        "postcss-reduce-idents": "^5.1.0",
-        "postcss-zindex": "^5.1.0"
+        "cssnano-preset-default": "^*",
+        "postcss-discard-unused": "^*",
+        "postcss-merge-idents": "^*",
+        "postcss-reduce-idents": "^*",
+        "postcss-zindex": "^*"
       }
     },
     "cssnano-preset-default": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.3.tgz",
-      "integrity": "sha512-e4pzD/FnsvRywKO3i2Ti4jgAcJO5MhQPudrex92HXAJoMyQfS8lZHIzzC1yZ1t+d2zdkLXFY1sHdsZaT7lKoCQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.4.tgz",
+      "integrity": "sha512-w1Gg8xsebln6/axZ6qDFQHuglrGfbIHOIx0g4y9+etRlRab8CGpSpe6UMsrgJe4zhCaJ0LwLmc+PhdLRTwnhIA==",
       "requires": {
         "css-declaration-sorter": "^6.0.3",
-        "cssnano-utils": "^3.1.0",
+        "cssnano-utils": "^*",
         "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.0",
-        "postcss-discard-comments": "^5.1.1",
-        "postcss-discard-duplicates": "^5.1.0",
-        "postcss-discard-empty": "^5.1.1",
-        "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.1",
-        "postcss-merge-rules": "^5.1.0",
-        "postcss-minify-font-values": "^5.1.0",
-        "postcss-minify-gradients": "^5.1.0",
-        "postcss-minify-params": "^5.1.1",
-        "postcss-minify-selectors": "^5.2.0",
-        "postcss-normalize-charset": "^5.1.0",
-        "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.0",
-        "postcss-normalize-repeat-style": "^5.1.0",
-        "postcss-normalize-string": "^5.1.0",
-        "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
-        "postcss-normalize-url": "^5.1.0",
-        "postcss-normalize-whitespace": "^5.1.1",
-        "postcss-ordered-values": "^5.1.0",
-        "postcss-reduce-initial": "^5.1.0",
-        "postcss-reduce-transforms": "^5.1.0",
-        "postcss-svgo": "^5.1.0",
-        "postcss-unique-selectors": "^5.1.1"
+        "postcss-colormin": "^*",
+        "postcss-convert-values": "^*",
+        "postcss-discard-comments": "^*",
+        "postcss-discard-duplicates": "^*",
+        "postcss-discard-empty": "^*",
+        "postcss-discard-overridden": "^*",
+        "postcss-merge-longhand": "^*",
+        "postcss-merge-rules": "^*",
+        "postcss-minify-font-values": "^*",
+        "postcss-minify-gradients": "^*",
+        "postcss-minify-params": "^*",
+        "postcss-minify-selectors": "^*",
+        "postcss-normalize-charset": "^*",
+        "postcss-normalize-display-values": "^*",
+        "postcss-normalize-positions": "^*",
+        "postcss-normalize-repeat-style": "^*",
+        "postcss-normalize-string": "^*",
+        "postcss-normalize-timing-functions": "^*",
+        "postcss-normalize-unicode": "^*",
+        "postcss-normalize-url": "^*",
+        "postcss-normalize-whitespace": "^*",
+        "postcss-ordered-values": "^*",
+        "postcss-reduce-initial": "^*",
+        "postcss-reduce-transforms": "^*",
+        "postcss-svgo": "^*",
+        "postcss-unique-selectors": "^*"
       }
     },
     "cssnano-utils": {
@@ -4051,20 +3980,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
-    "eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.4.81",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.81.tgz",
-      "integrity": "sha512-Gs7xVpIZ7tYYSDA+WgpzwpPvfGwUk3KSIjJ0akuj5XQHFdyQnsUoM76EA4CIHXNLPiVwTwOFay9RMb0ChG3OBw=="
+      "version": "1.4.82",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.82.tgz",
+      "integrity": "sha512-Ks+ANzLoIrFDUOJdjxYMH6CMKB8UQo5modAwvSZTxgF+vEs/U7G5IbWFUp6dS4klPkTDVdxbORuk8xAXXhMsWw=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -4422,9 +4346,9 @@
       }
     },
     "filesize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
-      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -4797,25 +4721,15 @@
         "kind-of": "^6.0.2",
         "section-matter": "^1.0.0",
         "strip-bom-string": "^1.0.0"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "gzip-size": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
       "requires": {
-        "duplexer": "^0.1.2"
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
       }
     },
     "handle-thing": {
@@ -5183,14 +5097,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
-    "image-size": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
-      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
-      "requires": {
-        "queue": "6.0.2"
-      }
-    },
     "immer": {
       "version": "9.0.12",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
@@ -5253,14 +5159,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "ip": {
       "version": "1.1.5",
@@ -5532,18 +5430,12 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
-        "argparse": "^2.0.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        }
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsesc": {
@@ -5776,6 +5668,14 @@
         "yallist": "^4.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5890,16 +5790,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -5922,46 +5822,27 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.0.tgz",
-      "integrity": "sha512-ndG8nxCEnAemsg4FSgS+yNyHKgkTB4nPKqCOgh65j3/30qqC5RaSQQXMm++Y6sb6E1zRSxPkztj9fqxhS1Eo6w==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
+      "integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
       "requires": {
-        "schema-utils": "^4.0.0"
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0",
+        "webpack-sources": "^1.1.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
-        "ajv-keywords": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
           "requires": {
-            "fast-deep-equal": "^3.1.3"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "schema-utils": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "ajv": "^8.8.0",
-            "ajv-formats": "^2.1.1",
-            "ajv-keywords": "^5.0.0"
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -6167,13 +6048,12 @@
       }
     },
     "open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "opener": {
@@ -6293,14 +6173,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
-    "parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "requires": {
-        "parse5": "^6.0.1"
-      }
-    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6362,6 +6234,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -6517,12 +6394,12 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.1.tgz",
-      "integrity": "sha512-JLtqAY1LvxiD2aej6hcAk/TkXvEPM+Gs1aOkOIZub2MDEiB5NMtpMe/Ir2seIMMM245bsuHggzIhQBv6qFBm4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.2.tgz",
+      "integrity": "sha512-18/bp9DZnY1ai9RlahOfLBbmIUKfKFPASxRCiZ1vlpZqWPCn8qWPFlEozqmWL+kBtcEQmG8W9YqGCstDImvp/Q==",
       "requires": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^*"
       }
     },
     "postcss-merge-rules": {
@@ -6874,14 +6751,6 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
-    "queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "requires": {
-        "inherits": "~2.0.3"
-      }
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6950,66 +6819,36 @@
       }
     },
     "react-dev-utils": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
-      "integrity": "sha512-xBQkitdxozPxt1YZ9O1097EJiVpwHr9FoAuEVURCKV0Av8NBERovJauzP7bo1ThvuhZ4shsQ1AJiu4vQpoT1AQ==",
+      "version": "12.0.0-next.47",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0-next.47.tgz",
+      "integrity": "sha512-PsE71vP15TZMmp/RZKOJC4fYD5Pvt0+wCoyG3QHclto0d4FyIJI78xGRICOOThZFROqgXYlZP6ddmeybm+jO4w==",
       "requires": {
-        "@babel/code-frame": "^7.16.0",
+        "@babel/code-frame": "^7.10.4",
         "address": "^1.1.2",
-        "browserslist": "^4.18.1",
-        "chalk": "^4.1.2",
+        "browserslist": "^4.16.5",
+        "chalk": "^2.4.2",
         "cross-spawn": "^7.0.3",
         "detect-port-alt": "^1.1.6",
-        "escape-string-regexp": "^4.0.0",
-        "filesize": "^8.0.6",
-        "find-up": "^5.0.0",
-        "fork-ts-checker-webpack-plugin": "^6.5.0",
+        "escape-string-regexp": "^2.0.0",
+        "filesize": "^6.1.0",
+        "find-up": "^4.1.0",
+        "fork-ts-checker-webpack-plugin": "^6.0.5",
         "global-modules": "^2.0.0",
-        "globby": "^11.0.4",
-        "gzip-size": "^6.0.0",
-        "immer": "^9.0.7",
+        "globby": "^11.0.1",
+        "gzip-size": "^5.1.1",
+        "immer": "^9.0.6",
         "is-root": "^2.1.0",
-        "loader-utils": "^3.2.0",
-        "open": "^8.4.0",
+        "loader-utils": "^2.0.0",
+        "open": "^7.0.2",
         "pkg-up": "^3.1.0",
-        "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.10",
+        "prompts": "^2.4.0",
+        "react-error-overlay": "7.0.0-next.54+1465357b",
         "recursive-readdir": "^2.2.2",
-        "shell-quote": "^1.7.3",
-        "strip-ansi": "^6.0.1",
+        "shell-quote": "^1.7.2",
+        "strip-ansi": "^6.0.0",
         "text-table": "^0.2.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7028,65 +6867,19 @@
           }
         },
         "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "loader-utils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-          "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ=="
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
+        "react-error-overlay": {
+          "version": "7.0.0-next.54",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-7.0.0-next.54.tgz",
+          "integrity": "sha512-b96CiTnZahXPDNH9MKplvt5+jD+BkxDw7q5R3jnkUXze/ux1pLv32BBZmlj0OfCUeMqyz4sAmF+0ccJGVMlpXw=="
         }
       }
     },
@@ -7110,16 +6903,15 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
-    "react-helmet-async": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.2.3.tgz",
-      "integrity": "sha512-mCk2silF53Tq/YaYdkl2sB+/tDoPnaxN7dFS/6ZLJb/rhUY2EWGI5Xj2b4jHppScMqY45MbgPSwTxDchKpZ5Kw==",
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "invariant": "^2.2.4",
+        "object-assign": "^4.1.1",
         "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.2.0",
-        "shallowequal": "^1.1.0"
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
       }
     },
     "react-is": {
@@ -7198,6 +6990,11 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
     },
     "react-textarea-autosize": {
       "version": "8.3.3",
@@ -7491,6 +7288,42 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "remark-mdx-remove-exports": {
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/remark-mdx-remove-exports/-/remark-mdx-remove-exports-1.6.22.tgz",
+      "integrity": "sha512-7g2uiTmTGfz5QyVb+toeX25frbk1Y6yd03RXGPtqx0+DVh86Gb7MkNYbk7H2X27zdZ3CQv1W/JqlFO0Oo8IxVA==",
+      "requires": {
+        "unist-util-remove": "2.0.0"
+      },
+      "dependencies": {
+        "unist-util-remove": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-2.0.0.tgz",
+          "integrity": "sha512-HwwWyNHKkeg/eXRnE11IpzY8JT55JNM1YCwwU9YNCnfzk6s8GhPXrVBBZWiwLeATJbI7euvoGSzcy9M29UeW3g==",
+          "requires": {
+            "unist-util-is": "^4.0.0"
+          }
+        }
+      }
+    },
+    "remark-mdx-remove-imports": {
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/remark-mdx-remove-imports/-/remark-mdx-remove-imports-1.6.22.tgz",
+      "integrity": "sha512-lmjAXD8Ltw0TsvBzb45S+Dxx7LTJAtDaMneMAv8LAUIPEyYoKkmGbmVsiF0/pY6mhM1Q16swCmu1TN+ie/vn/A==",
+      "requires": {
+        "unist-util-remove": "2.0.0"
+      },
+      "dependencies": {
+        "unist-util-remove": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-2.0.0.tgz",
+          "integrity": "sha512-HwwWyNHKkeg/eXRnE11IpzY8JT55JNM1YCwwU9YNCnfzk6s8GhPXrVBBZWiwLeATJbI7euvoGSzcy9M29UeW3g==",
+          "requires": {
+            "unist-util-is": "^4.0.0"
+          }
         }
       }
     },
@@ -7944,11 +7777,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8059,6 +7887,11 @@
         }
       }
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
@@ -8115,33 +7948,13 @@
       "integrity": "sha512-mC1Ps9l77/97qeOZc+HrOL7TIaOboHqMZ24dGVQrlxFcpPpfCHpH+qfUT7Dz+6mlG8+JPA1KfBQo19iC/+Ngcw=="
     },
     "string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       }
     },
     "string_decoder": {
@@ -8264,6 +8077,11 @@
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        },
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -8374,9 +8192,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "type-fest": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.0.tgz",
-      "integrity": "sha512-Qe5GRT+n/4GoqCNGGVp5Snapg1Omq3V7irBJB3EaKsp7HWDo5Gv2d/67gfNyV+d5EXD+x/RF5l1h4yJ7qNkcGA=="
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -8556,21 +8374,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "boxen": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-          "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-          "requires": {
-            "ansi-align": "^3.0.0",
-            "camelcase": "^6.2.0",
-            "chalk": "^4.1.0",
-            "cli-boxes": "^2.2.1",
-            "string-width": "^4.2.2",
-            "type-fest": "^0.20.2",
-            "widest-line": "^3.1.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8579,11 +8382,6 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
-        },
-        "cli-boxes": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-          "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
         },
         "color-convert": {
           "version": "2.0.1",
@@ -8603,45 +8401,12 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
-        },
-        "widest-line": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-          "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-          "requires": {
-            "string-width": "^4.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -8834,6 +8599,13 @@
         "terser-webpack-plugin": "^5.1.3",
         "watchpack": "^2.3.1",
         "webpack-sources": "^3.2.3"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        }
       }
     },
     "webpack-bundle-analyzer": {
@@ -8852,6 +8624,11 @@
         "ws": "^7.3.1"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -8886,6 +8663,14 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
           "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        },
+        "gzip-size": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+          "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+          "requires": {
+            "duplexer": "^0.1.2"
+          }
         },
         "has-flag": {
           "version": "4.0.0",
@@ -9022,6 +8807,16 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
+        "open": {
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+          "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+          "requires": {
+            "define-lazy-prop": "^2.0.0",
+            "is-docker": "^2.1.1",
+            "is-wsl": "^2.2.0"
+          }
+        },
         "schema-utils": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -9151,11 +8946,11 @@
       }
     },
     "widest-line": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
-        "string-width": "^5.0.1"
+        "string-width": "^4.0.0"
       }
     },
     "wildcard": {
@@ -9164,32 +8959,35 @@
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
     },
     "wrap-ansi": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
-      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
         "ansi-styles": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
-          "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ=="
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "ansi-regex": "^6.0.1"
+            "color-convert": "^2.0.1"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         }
       }
     },

--- a/website/package.json
+++ b/website/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.17",
-    "@docusaurus/preset-classic": "2.0.0-beta.17",
+    "@docusaurus/core": "2.0.0-beta.14",
+    "@docusaurus/preset-classic": "2.0.0-beta.14",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
     "react": "^17.0.1",


### PR DESCRIPTION
Close #151  - Upgrade libraries
* sbt-github-pages `0.8.1` => `0.9.0`
* cats `2.6.1` => `2.7.0`
* cats-effect `2.5.3` => `3.3.5`
* github4s `0.28.5` => `0.31.0`
* http4s `0.21.27` => `0.23.11`
* effectie `1.15.0` => `2.0.0-beta1`
* logger-f `1.15.0` => `2.0.0-beta1`
* hedgehog `0.7.0` => `0.8.0`
***
Add `extras-cats` `0.13.0`