### PR TITLE
sbt-docusaur v0.10.0

### DIFF
--- a/changelogs/0.10.0.md
+++ b/changelogs/0.10.0.md
@@ -1,0 +1,14 @@
+## [0.10.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16) - 2022-05-05
+
+### Done
+* Upgrade libraries (#151)
+  * sbt-github-pages `0.8.1` => `0.9.0`
+  * cats `2.6.1` => `2.7.0`
+  * cats-effect `2.5.3` => `3.3.5`
+  * github4s `0.28.5` => `0.31.0`
+  * http4s `0.21.27` => `0.23.11`
+  * effectie `1.15.0` => `2.0.0-beta1`
+  * logger-f `1.15.0` => `2.0.0-beta1`
+  * hedgehog `0.7.0` => `0.8.0`
+***
+* Add `extras-cats` `0.13.0`


### PR DESCRIPTION
# sbt-docusaur v0.10.0
## [0.10.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16) - 2022-05-05

### Done
* Upgrade libraries (#151)
  * sbt-github-pages `0.8.1` => `0.9.0`
  * cats `2.6.1` => `2.7.0`
  * cats-effect `2.5.3` => `3.3.5`
  * github4s `0.28.5` => `0.31.0`
  * http4s `0.21.27` => `0.23.11`
  * effectie `1.15.0` => `2.0.0-beta1`
  * logger-f `1.15.0` => `2.0.0-beta1`
  * hedgehog `0.7.0` => `0.8.0`
***
* Add `extras-cats` `0.13.0`
