### PR TITLE
sbt-docusaur v0.11.0

### DIFF
--- a/changelogs/0.11.0.md
+++ b/changelogs/0.11.0.md
@@ -1,0 +1,10 @@
+## [0.11.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone17) - 2022-05-21
+
+### Done
+* Upgrade `sbt-github-pages` to `0.10.0` (#154)
+  * This version supports request timeout for publishing GitHub Pages
+* Upgrade libraries and sbt plugins (#155)
+  * cats-effect `3.3.5` => `3.3.12`
+  * extras `0.13.0` => `0.14.0`
+  * sbt-docusaur `0.9.0` => `0.10.0`
+  * sbt-devoops `2.16.0` => `2.20.0`


### PR DESCRIPTION
# sbt-docusaur v0.11.0
## [0.11.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone17) - 2022-05-21

### Done
* Upgrade `sbt-github-pages` to `0.10.0` (#154)
  * This version supports request timeout for publishing GitHub Pages
* Upgrade libraries and sbt plugins (#155)
  * cats-effect `3.3.5` => `3.3.12`
  * extras `0.13.0` => `0.14.0`
  * sbt-docusaur `0.9.0` => `0.10.0`
  * sbt-devoops `2.16.0` => `2.20.0`