### PR TITLE
Upgrade: sbt plugins - sbt-docusaur 0.10.0 => 0.11.0 / sbt-devoops 2.20.0 => 2.22.0 / add sbt-devoops-starter

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,10 @@ logLevel := sbt.Level.Warn
 
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.10.0")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.11.0")
 
-val sbtDevOopsVersion = "2.20.0"
+val sbtDevOopsVersion = "2.22.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
+
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"    % sbtDevOopsVersion)


### PR DESCRIPTION
Upgrade: sbt plugins - `sbt-docusaur` `0.10.0` => `0.11.0` / `sbt-devoops` `2.20.0` => `2.22.0` / add `sbt-devoops-starter`