### PR TITLE
Close #164 - Upgrade Scala, sbt, sbt-plugins and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val props =
     final val GitHubUsername = gitHubRepo.fold("Kevin-Lee")(_.orgToString)
     final val ProjectName    = gitHubRepo.fold("sbt-docusaur")(_.nameToString)
 
-    final val ProjectScalaVersion = "2.12.12"
+    final val ProjectScalaVersion = "2.12.17"
 
     val CrossScalaVersions: Seq[String] = Seq(ProjectScalaVersion)
 
@@ -75,18 +75,21 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val SbtGitHubPagesVersion = "0.10.0"
+    final val SbtGitHubPagesVersion = "0.11.0"
 
-    final val catsVersion       = "2.7.0"
-    final val catsEffectVersion = "3.3.12"
-    final val http4sVersion     = "0.23.11"
-    final val github4sVersion   = "0.31.0"
+    final val catsVersion       = "2.8.0"
+    final val catsEffectVersion = "3.3.14"
 
-    final val effectieVersion       = "2.0.0-beta1"
-    final val loggerFVersion        = "2.0.0-beta1"
+    final val http4sVersion            = "0.23.16"
+    final val http4sBlazeClientVersion = "0.23.12"
+
+    final val github4sVersion = "0.31.2"
+
+    final val effectieVersion       = "2.0.0-beta2"
+    final val loggerFVersion        = "2.0.0-beta2"
     final val justSysprocessVersion = "1.0.0"
 
-    final val ExtrasVersion = "0.14.0"
+    final val ExtrasVersion = "0.20.0"
 
     final val hedgehogVersion = "0.9.0"
   }
@@ -103,8 +106,8 @@ lazy val libs =
     lazy val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % props.catsEffectVersion
     lazy val github4s: ModuleID   = "com.47deg"     %% "github4s"    % props.github4sVersion
 
-    lazy val http4sDsl: ModuleID    = "org.http4s" %% "http4s-dsl"          % props.http4sVersion
-    lazy val http4sClient: ModuleID = "org.http4s" %% "http4s-blaze-client" % props.http4sVersion
+    lazy val http4sDsl: ModuleID = "org.http4s" %% "http4s-dsl"          % props.http4sVersion
+    lazy val http4sClient        = "org.http4s" %% "http4s-blaze-client" % props.http4sBlazeClientVersion
 
     lazy val effectie: ModuleID          = "io.kevinlee" %% "effectie-cats-effect3" % props.effectieVersion
     lazy val loggerFCatsEffect: ModuleID = "io.kevinlee" %% "logger-f-cats"         % props.loggerFVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 logLevel := sbt.Level.Warn
 
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.6")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.11.0")
 
-val sbtDevOopsVersion = "2.22.0"
+val sbtDevOopsVersion = "2.23.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 

--- a/src/main/scala/docusaur/DocusaurPlugin.scala
+++ b/src/main/scala/docusaur/DocusaurPlugin.scala
@@ -3,12 +3,12 @@ package docusaur
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 import docusaur.npm.{Npm, NpmCmd, NpmError}
-import effectie.cats.fx.ioFx
+import effectie.ce3.fx.ioFx
 import extras.cats.syntax.either._
 import filef.FileError2
 import githubpages.GitHubPagesPlugin
 import githubpages.GitHubPagesPlugin.{autoImport => ghpg}
-import loggerf.cats.instances.logF
+import loggerf.instances.cats.logF
 import loggerf.logger._
 import sbt.Keys.streams
 import sbt.util.Logger


### PR DESCRIPTION
Close #164 - Upgrade Scala, sbt, sbt-plugins and libraries
* sbt `1.6.2` => `1.7.2`
* Scala `2.12.12` => `2.12.17`
* sbt-github-pages `0.10.0` => `0.11.0`
* cats `2.7.0` => `2.8.0`
* cats-effect `3.3.12` => `3.3.14`
* github4s `0.31.0` => `0.31.2`
* http4s `0.23.11` => `0.23.16`
* http4s-blaze-client `0.23.11` => `0.23.12`
* effectie `2.0.0-beta1` => `2.0.0-beta2`
* logger-f `2.0.0-beta1` => `2.0.0-beta2`
* extras `0.14.0` => `0.20.0`
* Other sbt plugins