### PR TITLE
sbt-docusaur v0.12.0

### DIFF
--- a/changelogs/0.12.0.md
+++ b/changelogs/0.12.0.md
@@ -1,0 +1,16 @@
+## [0.12.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2022-10-05
+
+### Done
+* Upgrade Scala, sbt, sbt-plugins and libraries (#164)
+  * sbt `1.6.2` => `1.7.2`
+  * Scala `2.12.12` => `2.12.17`
+  * sbt-github-pages `0.10.0` => `0.11.0`
+  * cats `2.7.0` => `2.8.0`
+  * cats-effect `3.3.12` => `3.3.14`
+  * github4s `0.31.0` => `0.31.2`
+  * http4s `0.23.11` => `0.23.16`
+  * http4s-blaze-client `0.23.11` => `0.23.12`
+  * effectie `2.0.0-beta1` => `2.0.0-beta2`
+  * logger-f `2.0.0-beta1` => `2.0.0-beta2`
+  * extras `0.14.0` => `0.20.0`
+  * Other sbt plugins


### PR DESCRIPTION
# sbt-docusaur v0.12.0
## [0.12.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2022-10-05

### Done
* Upgrade Scala, sbt, sbt-plugins and libraries (#164)
  * sbt `1.6.2` => `1.7.2`
  * Scala `2.12.12` => `2.12.17`
  * sbt-github-pages `0.10.0` => `0.11.0`
  * cats `2.7.0` => `2.8.0`
  * cats-effect `3.3.12` => `3.3.14`
  * github4s `0.31.0` => `0.31.2`
  * http4s `0.23.11` => `0.23.16`
  * http4s-blaze-client `0.23.11` => `0.23.12`
  * effectie `2.0.0-beta1` => `2.0.0-beta2`
  * logger-f `2.0.0-beta1` => `2.0.0-beta2`
  * extras `0.14.0` => `0.20.0`
  * Other sbt plugins