### PR TITLE
Close #172 - Upgrade effectie and logger-f to 2.0.0-beta4, and sbt-github-pages to 0.12.0 / update the code accordingly / also upgrade other libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,27 +71,27 @@ lazy val props =
 
     val CrossScalaVersions: Seq[String] = Seq(ProjectScalaVersion)
 
-    final val GlobalSbtVersion = "1.2.8"
+    final val GlobalSbtVersion = "1.6.2"
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val SbtGitHubPagesVersion = "0.11.0"
+    final val SbtGitHubPagesVersion = "0.12.0"
 
-    final val catsVersion       = "2.8.0"
-    final val catsEffectVersion = "3.3.14"
+    final val catsVersion       = "2.9.0"
+    final val catsEffectVersion = "3.4.3"
 
     final val http4sVersion            = "0.23.16"
-    final val http4sBlazeClientVersion = "0.23.12"
+    final val http4sBlazeClientVersion = "0.23.13"
 
     final val github4sVersion = "0.31.2"
 
-    final val effectieVersion       = "2.0.0-beta2"
-    final val loggerFVersion        = "2.0.0-beta2"
+    final val effectieVersion       = "2.0.0-beta4"
+    final val loggerFVersion        = "2.0.0-beta4"
     final val justSysprocessVersion = "1.0.0"
 
-    final val ExtrasVersion = "0.20.0"
+    final val ExtrasVersion = "0.26.0"
 
-    final val hedgehogVersion = "0.9.0"
+    final val hedgehogVersion = "0.10.1"
   }
 
 lazy val libs =

--- a/src/main/scala/docusaur/Docusaur.scala
+++ b/src/main/scala/docusaur/Docusaur.scala
@@ -1,17 +1,17 @@
 package docusaur
 
-import cats._
+import cats.*
 import cats.data.EitherT
-import cats.syntax.all._
+import cats.syntax.all.*
 import docusaur.npm.Npm.NpmPath
 import docusaur.npm.{Npm, NpmCmd, NpmError}
 import effectie.core.Fx
-import effectie.syntax.all._
-import extras.cats.syntax.either._
+import effectie.syntax.all.*
+import extras.cats.syntax.either.*
 import filef.{FileError2, FileF2}
-import loggerf.core.syntax.all._
-import loggerf.core.{Log => LogF}
-import sbt.{IO => SbtIo}
+import loggerf.core.Log as LogF
+import loggerf.core.syntax.all.*
+import sbt.IO as SbtIo
 
 import java.io.File
 import java.nio.charset.Charset
@@ -54,12 +54,13 @@ object Docusaur {
     result <- EitherT(
                 Npm.run[F](npmPath, path.some, npmCmd)
               )
-    _      <- pureOf(
+    _      <-
                 s"""Successfully run npm for $what
                    |  - command: npm run ${NpmCmd.values(npmCmd).mkString(" ")}
                    |${result.mkString("  ", "\n  ", "\n")}
-                   |""".stripMargin
-              ).log(info).rightT[NpmError]
+                   |"""
+                  .stripMargin.logS_(info)
+                  .rightT[NpmError]
   } yield ()).value
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
@@ -69,7 +70,7 @@ object Docusaur {
   )(
     logMessage: String
   ): F[Unit] =
-    log(pureOf(logMessage))(info) >>
+    logS_(logMessage)(info) *>
       effectOf(
         SbtIo.write(
           theFile,

--- a/src/main/scala/docusaur/DocusaurKeys.scala
+++ b/src/main/scala/docusaur/DocusaurKeys.scala
@@ -1,8 +1,8 @@
 package docusaur
 
-import java.io.File
+import sbt.*
 
-import sbt._
+import java.io.File
 
 /** @author Kevin Lee
   * @since 2020-06-17

--- a/src/main/scala/docusaur/DocusaurPlugin.scala
+++ b/src/main/scala/docusaur/DocusaurPlugin.scala
@@ -1,18 +1,18 @@
 package docusaur
 
-import cats.effect._
+import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import docusaur.npm.{Npm, NpmCmd, NpmError}
-import effectie.ce3.fx.ioFx
-import extras.cats.syntax.either._
+import effectie.instances.ce3.fx.ioFx
+import extras.cats.syntax.either.*
 import filef.FileError2
 import githubpages.GitHubPagesPlugin
-import githubpages.GitHubPagesPlugin.{autoImport => ghpg}
+import githubpages.GitHubPagesPlugin.autoImport as ghpg
 import loggerf.instances.cats.logF
-import loggerf.logger._
+import loggerf.logger.*
 import sbt.Keys.streams
 import sbt.util.Logger
-import sbt.{IO => _, _}
+import sbt.{IO as _, *}
 
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 
@@ -25,7 +25,7 @@ object DocusaurPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = noTrigger
 
   object autoImport extends DocusaurKeys
-  import autoImport._
+  import autoImport.*
 
   private val internalLogger: ConcurrentMap[String, CanLog] =
     new ConcurrentHashMap(1)

--- a/src/main/scala/docusaur/npm/Npm.scala
+++ b/src/main/scala/docusaur/npm/Npm.scala
@@ -1,10 +1,10 @@
 package docusaur.npm
 
-import cats._
-import cats.syntax.all._
+import cats.*
+import cats.syntax.all.*
 import effectie.core.Fx
-import effectie.syntax.all._
-import extras.cats.syntax.either._
+import effectie.syntax.all.*
+import extras.cats.syntax.either.*
 import just.sysprocess.{ProcessError, ProcessResult, SysProcess}
 
 import java.io.File

--- a/src/main/scala/filef/FileError2.scala
+++ b/src/main/scala/filef/FileError2.scala
@@ -1,8 +1,8 @@
 package filef
 
-import java.io.File
-
 import errors.StackTraceToString
+
+import java.io.File
 
 /** @author Kevin Lee
   * @since 2020-06-06

--- a/src/main/scala/filef/FileF2.scala
+++ b/src/main/scala/filef/FileF2.scala
@@ -1,12 +1,12 @@
 package filef
 
-import cats._
+import cats.*
 import cats.data.EitherT
-import cats.syntax.flatMap._
-import cats.syntax.traverse._
+import cats.syntax.flatMap.*
+import cats.syntax.traverse.*
 import effectie.core.Fx
-import effectie.syntax.all._
-import extras.cats.syntax.all._
+import effectie.syntax.all.*
+import extras.cats.syntax.all.*
 
 import java.io.File
 import scala.annotation.tailrec
@@ -33,9 +33,9 @@ object FileF2 {
       list         <- effectOf(file.listFiles.toList).rightT
       allFiles     <- effectOf(listAllIn(list, Nil)).rightT
       filesDeleted <- allFiles.traverse[ET, String] { file =>
-                        (effectOf(file.delete()) >> effectOf(file.getCanonicalPath))
-                          .catchNonFatal(throwable => FileError2.inDeletion(file, throwable))
-                          .eitherT
+                        (effectOf(file.delete()) >> effectOf(file.getCanonicalPath)).catchNonFatal {
+                          case throwable => FileError2.inDeletion(file, throwable)
+                        }.eitherT
                       }
 
     } yield filesDeleted).value


### PR DESCRIPTION
Close #172 - Upgrade effectie and logger-f to 2.0.0-beta4, and sbt-github-pages to 0.12.0 / update the code accordingly / also upgrade other libraries
- effectie 2.0.0-beta2 => 2.0.0-beta4
- logger-f 2.0.0-beta2 => 2.0.0-beta4
- sbt-github-pages 0.11.0 => 0.12.0
- global sbt version 1.2.8 => 1.6.2
- hedgehog 0.9.0 => 0.10.1
- cats 2.8.0 => 2.9.0
- cats-effect 3.3.14 => 3.4.3
- http4s blaze client 0.23.12 => 0.23.13
- extras 0.20.0 => 0.26.0