### PR TITLE
sbt-docusaur v0.13.0

### DIFF
--- a/changelogs/0.13.0.md
+++ b/changelogs/0.13.0.md
@@ -1,0 +1,13 @@
+## [0.13.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2022-12-28
+
+### Done
+* Upgrade `effectie` and `logger-f` to `2.0.0-beta4`, and `sbt-github-pages` to `0.12.0` (#172) - update the code accordingly / also upgrade other libraries
+  * effectie`2.0.0-beta2` => `2.0.0-beta4`
+  * logger-f`2.0.0-beta2` => `2.0.0-beta4`
+  * sbt-github-pages`0.11.0` => `0.12.0`
+  * global sbt version`1.2.8` => `1.6.2`
+  * hedgehog`0.9.0` => `0.10.1`
+  * cats`2.8.0` => `2.9.0`
+  * cats-effect`3.3.14` => `3.4.3`
+  * http4s blaze client`0.23.12` => `0.23.13`
+  * extras`0.20.0` => `0.26.0`


### PR DESCRIPTION
# sbt-docusaur v0.13.0
## [0.13.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2022-12-28

### Done
* Upgrade `effectie` and `logger-f` to `2.0.0-beta4`, and `sbt-github-pages` to `0.12.0` (#172) - update the code accordingly / also upgrade other libraries
  * effectie`2.0.0-beta2` => `2.0.0-beta4`
  * logger-f`2.0.0-beta2` => `2.0.0-beta4`
  * sbt-github-pages`0.11.0` => `0.12.0`
  * global sbt version`1.2.8` => `1.6.2`
  * hedgehog`0.9.0` => `0.10.1`
  * cats`2.8.0` => `2.9.0`
  * cats-effect`3.3.14` => `3.4.3`
  * http4s blaze client`0.23.12` => `0.23.13`
  * extras`0.20.0` => `0.26.0`
