### PR TITLE
Close #190 - Upgrade Scala, sbt, sbt plugins and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val root = (project in file("."))
     name := props.ProjectName,
     description := "sbt plugin to publish GitHub Pages",
     crossSbtVersions := props.CrossSbtVersions,
-    pluginCrossBuild / sbtVersion := "1.2.8",
+    pluginCrossBuild / sbtVersion := props.GlobalSbtVersion,
     libraryDependencies ++= libs.all,
     testFrameworks ~= (fws => (TestFramework("hedgehog.sbt.Framework") +: fws).distinct),
     addSbtPlugin("io.kevinlee" % "sbt-github-pages" % props.SbtGitHubPagesVersion),
@@ -67,7 +67,7 @@ lazy val props =
     final val GitHubUsername = gitHubRepo.fold("Kevin-Lee")(_.orgToString)
     final val ProjectName    = gitHubRepo.fold("sbt-docusaur")(_.nameToString)
 
-    final val ProjectScalaVersion = "2.12.17"
+    final val ProjectScalaVersion = "2.12.18"
 
     val CrossScalaVersions: Seq[String] = Seq(ProjectScalaVersion)
 
@@ -75,28 +75,28 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val SbtGitHubPagesVersion = "0.12.0"
+    final val SbtGitHubPagesVersion = "0.13.0"
 
-    final val CatsVersion       = "2.9.0"
-    final val CatsEffectVersion = "3.4.3"
+    final val CatsVersion       = "2.10.0"
+    final val CatsEffectVersion = "3.5.2"
 
-    final val Http4sVersion            = "0.23.16"
-    final val Http4sBlazeClientVersion = "0.23.13"
+    final val Http4sVersion            = "0.23.24"
+    final val Http4sBlazeClientVersion = "0.23.15"
 
-    final val Github4sVersion = "0.31.2"
+    final val Github4sVersion = "0.32.1"
 
-    final val EffectieVersion = "2.0.0-beta4"
-    final val LoggerFVersion  = "2.0.0-beta4"
+    final val EffectieVersion = "2.0.0-beta13"
+    final val LoggerFVersion  = "2.0.0-beta22"
 
     val LogbackVersion = "1.3.11"
 
     final val JustSysprocessVersion = "1.0.0"
 
-    final val ExtrasVersion = "0.26.0"
+    final val ExtrasVersion = "0.44.0"
 
     final val HedgehogVersion = "0.10.1"
 
-    val CirceVersion = "0.14.1"
+    val CirceVersion = "0.14.6"
   }
 
 lazy val libs =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.6")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.5")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.13.0")
 
-val sbtDevOopsVersion = "2.24.0"
+val sbtDevOopsVersion = "3.0.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % sbtDevOopsVersion)

--- a/src/main/scala/docusaur/Docusaur.scala
+++ b/src/main/scala/docusaur/Docusaur.scala
@@ -22,7 +22,6 @@ import java.nio.charset.Charset
 object Docusaur {
 
   def deleteFilesIn[F[_]: Fx: Monad](
-    what: String,
     file: File
   ): F[Either[FileError2, List[String]]] =
     FileF2.deleteAllIn[F](file)

--- a/src/main/scala/docusaur/DocusaurPlugin.scala
+++ b/src/main/scala/docusaur/DocusaurPlugin.scala
@@ -61,7 +61,7 @@ object DocusaurPlugin extends AutoPlugin {
         Def.task(
           returnOrThrowMessageOnlyException(
             (for {
-              files <- Docusaur.deleteFilesIn("'clean node_modules'", nodeModulesPath).eitherT
+              files <- Docusaur.deleteFilesIn(nodeModulesPath).eitherT // clean node_modules
               _     <- log.info(toFileRemovalMessage(nodeModulesPath, files)).rightTF[IO, FileError2]
             } yield ())
               .value
@@ -96,7 +96,7 @@ object DocusaurPlugin extends AutoPlugin {
         Def.task(
           returnOrThrowMessageOnlyException(
             (for {
-              files <- Docusaur.deleteFilesIn[IO]("'clean the Docusaurus build dir'", buildPath).eitherT
+              files <- Docusaur.deleteFilesIn[IO](buildPath).eitherT // clean the Docusaurus build dir
               _     <- streams
                          .value
                          .log

--- a/src/main/scala/filef/FileError2.scala
+++ b/src/main/scala/filef/FileError2.scala
@@ -16,7 +16,7 @@ object FileError2 {
   def inDeletion(file: File, throwable: Throwable): FileError2 = InDeletion(file, throwable)
 
   def render(fileError: FileError2): String = fileError match {
-    case InDeletion(file, throwable) =>
+    case InDeletion(file @ _, throwable) =>
       s"${StackTraceToString.render(throwable)}"
   }
 


### PR DESCRIPTION
Close #190 - Upgrade Scala, sbt, sbt plugins and libraries
* Scala to `2.12.18`
* sbt to `1.9.7`
* sbt-ci-release to `1.5.12`
* sbt-wartremover to `3.1.5`
* sbt-devoops to `3.0.0`
* sbt-github-pages to `0.13.0`
* cats to `2.10.0`
* cats-effect to `3.5.2`
* github4s to `0.32.1`
* circe to `0.14.6`
* http4s to `0.23.24`
* http4s-blaze-client to `0.23.15`
* effectie to `2.0.0-beta13`
* logger-f to `2.0.0-beta22`
* extras to `0.44.0`