### PR TITLE
Close #203 - Bump libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,14 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { binary-version: "2.12", java-version: "adopt@1.8" }
+          - { binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
 
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: olafurpg/setup-scala@v10
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.scala.java-version }}
+        distribution: ${{ matrix.scala.java-distribution }}
 
     - name: Cache SBT
       uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
       - '*'
 
 env:
-  GH_JAVA_VERSION: "adopt@1.8"
+  GH_JAVA_VERSION: "11"
+  GH_JAVA_DISTRIBUTION: "temurin"
   GH_SCALA_BINARY_VERSION: "2.12"
 
 jobs:
@@ -16,9 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: olafurpg/setup-scala@v10
+      - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.GH_JAVA_VERSION }}
+          distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
 
       - name: Cache SBT
         uses: actions/cache@v2

--- a/build.sbt
+++ b/build.sbt
@@ -75,20 +75,20 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val SbtGitHubPagesVersion = "0.13.0"
+    final val SbtGitHubPagesVersion = "0.14.0"
 
     final val CatsVersion       = "2.10.0"
-    final val CatsEffectVersion = "3.5.2"
+    final val CatsEffectVersion = "3.5.3"
 
-    final val Http4sVersion            = "0.23.24"
-    final val Http4sBlazeClientVersion = "0.23.15"
+    final val Http4sVersion            = "0.23.25"
+    final val Http4sBlazeClientVersion = "0.23.16"
 
     final val Github4sVersion = "0.32.1"
 
-    final val EffectieVersion = "2.0.0-beta13"
-    final val LoggerFVersion  = "2.0.0-beta22"
+    final val EffectieVersion = "2.0.0-beta14"
+    final val LoggerFVersion  = "2.0.0-beta24"
 
-    val LogbackVersion = "1.3.11"
+    val LogbackVersion = "1.4.11"
 
     final val JustSysprocessVersion = "1.0.0"
 


### PR DESCRIPTION
Close #203 - Bump libraries
- cats-effect to `3.5.3`
- http4s to `0.23.25`
- http4s-blaze-client to `0.23.16`
- effectie to `2.0.0-beta14`
- logger-f to `2.0.0-beta24`
- logback to `1.4.11`
- sbt-github-pages to `0.14.0`