### PR TITLE
sbt-docusaur v0.16.0

### DIFF
--- a/changelogs/0.16.0.md
+++ b/changelogs/0.16.0.md
@@ -1,0 +1,11 @@
+## [0.16.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22) - 2024-03-05
+
+### Internal Housekeeping
+* Bump libraries (#203)
+  * cats-effect to `3.5.3`
+  * http4s to `0.23.25`
+  * http4s-blaze-client to `0.23.16`
+  * effectie to `2.0.0-beta14`
+  * logger-f to `2.0.0-beta24`
+  * logback to `1.4.11`
+  * sbt-github-pages to `0.14.0`


### PR DESCRIPTION
# sbt-docusaur v0.16.0
## [0.16.0](https://github.com/Kevin-Lee/sbt-docusaur/issues?q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22) - 2024-03-05

### Internal Housekeeping
* Bump libraries (#203)
  * cats-effect to `3.5.3`
  * http4s to `0.23.25`
  * http4s-blaze-client to `0.23.16`
  * effectie to `2.0.0-beta14`
  * logger-f to `2.0.0-beta24`
  * logback to `1.4.11`
  * sbt-github-pages to `0.14.0`