### PR TITLE
Close #216 - Bump libraries and sbt plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,28 +75,28 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val SbtGitHubPagesVersion = "0.14.0"
+    final val SbtGitHubPagesVersion = "0.15.0"
 
-    final val CatsVersion       = "2.10.0"
-    final val CatsEffectVersion = "3.5.3"
+    final val CatsVersion       = "2.13.0"
+    final val CatsEffectVersion = "3.5.7"
 
-    final val Http4sVersion            = "0.23.25"
-    final val Http4sBlazeClientVersion = "0.23.16"
+    final val Http4sVersion            = "0.23.30"
+    final val Http4sBlazeClientVersion = "0.23.17"
 
-    final val Github4sVersion = "0.32.1"
+    final val Github4sVersion = "0.33.3"
 
-    final val EffectieVersion = "2.0.0-beta14"
-    final val LoggerFVersion  = "2.0.0-beta24"
+    final val EffectieVersion = "2.0.0"
+    final val LoggerFVersion  = "2.1.18"
 
-    val LogbackVersion = "1.4.11"
+    val LogbackVersion = "1.5.18"
 
     final val JustSysprocessVersion = "1.0.0"
 
     final val ExtrasVersion = "0.44.0"
 
-    final val HedgehogVersion = "0.10.1"
+    final val HedgehogVersion = "0.12.0"
 
-    val CirceVersion = "0.14.6"
+    val CirceVersion = "0.14.12"
   }
 
 lazy val libs =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.5")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.16.0")
 
-val sbtDevOopsVersion = "3.1.0"
+val sbtDevOopsVersion = "3.2.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % sbtDevOopsVersion)


### PR DESCRIPTION
# Close #216 - Bump libraries and sbt plugins

- Updated `sbt-github-pages` to 0.15.0
- Updated `cats-core` to 2.13.0
- Updated `cats-effect` to 3.5.7
- Updated `http4s` to 0.23.30
- Updated `http4s-blaze-client` to 0.23.17
- Updated `github4s` to 0.33.3
- Updated `effectie` to 2.0.0
- Updated `logger-f` to 2.1.18
- Updated `logback-classic` to 1.5.18
- Updated `hedgehog` to 0.12.0
- Updated `circe` to 0.14.12
- Updated `sbt-devoops` plugins to 3.2.0