### PR TITLE
sbt-docusaur v0.17.0

### DIFF
--- a/changelogs/0.17.0.md
+++ b/changelogs/0.17.0.md
@@ -1,0 +1,16 @@
+## [0.17.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Amilestone23) - 2025-04-06
+
+### Internal Housekeeping
+* Bump libraries and sbt plugins (#216)
+  - Updated `sbt-github-pages` to `0.15.0`
+  - Updated `cats-core` to `2.13.0`
+  - Updated `cats-effect` to `3.5.7`
+  - Updated `http4s` to `0.23.30`
+  - Updated `http4s-blaze-client` to `0.23.17`
+  - Updated `github4s` to `0.33.3`
+  - Updated `effectie` to `2.0.0`
+  - Updated `logger-f` to `2.1.18`
+  - Updated `logback-classic` to `1.5.18`
+  - Updated `hedgehog` to `0.12.0`
+  - Updated `circe` to `0.14.12`
+  - Updated `sbt-devoops` plugins to `3.2.0`


### PR DESCRIPTION
# sbt-docusaur v0.17.0
## [0.17.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Amilestone23) - 2025-04-06

### Internal Housekeeping
* Bump libraries and sbt plugins (#216)
  - Updated `sbt-github-pages` to `0.15.0`
  - Updated `cats-core` to `2.13.0`
  - Updated `cats-effect` to `3.5.7`
  - Updated `http4s` to `0.23.30`
  - Updated `http4s-blaze-client` to `0.23.17`
  - Updated `github4s` to `0.33.3`
  - Updated `effectie` to `2.0.0`
  - Updated `logger-f` to `2.1.18`
  - Updated `logback-classic` to `1.5.18`
  - Updated `hedgehog` to `0.12.0`
  - Updated `circe` to `0.14.12`
  - Updated `sbt-devoops` plugins to `3.2.0`
