### PR TITLE
Update docs: Bump sbt-docusaur to `v0.17.0` in examples and getting-started documentation

### DIFF
--- a/website/docs/examples.md
+++ b/website/docs/examples.md
@@ -44,7 +44,7 @@ Add `sbt-mdoc` plugin and `sbt-docusaur` to `project/plugins.sbt`.
 ```scala title="project/plugins.sbt"
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6" )
 
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.16.0")
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.17.0")
 ```
 
 In your `build.sbt`, add a sub-project for the doc site with `sbt-mdoc` and `sbt-docusaur`, and set up the Docusarus.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -19,7 +19,7 @@ sbt plugin for Docusaurus
 
 In the `project/plugins.sbt`, add the following line,
 ```scala
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.16.0")
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.17.0")
 ```
 
 In your `build.sbt`,


### PR DESCRIPTION
Update docs: Bump sbt-docusaur to `v0.17.0` in examples and getting-started documentation