### PR TITLE
Close #221: Update dependencies and build tools, and remove Sonatype publishing configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,6 @@ ThisBuild / startYear := 2020.some
 
 Global / sbtVersion := props.GlobalSbtVersion
 
-ThisBuild / resolvers += "sonatype-snapshots" at s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
-
 lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin, DevOopsGitHubReleasePlugin, DocusaurPlugin)
   .settings(
@@ -52,51 +50,47 @@ lazy val root = (project in file("."))
     /* } Docs */
 
   )
-  .settings(mavenCentralPublishSettings)
 
 lazy val props =
   new {
-
-    val SonatypeCredentialHost = "s01.oss.sonatype.org"
-    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
     final val Org = "io.kevinlee"
 
     private val gitHubRepo = findRepoOrgAndName
 
-    final val GitHubUsername = gitHubRepo.fold("Kevin-Lee")(_.orgToString)
+    final val GitHubUsername = gitHubRepo.fold("kevin-lee")(_.orgToString)
     final val ProjectName    = gitHubRepo.fold("sbt-docusaur")(_.nameToString)
 
     final val ProjectScalaVersion = "2.12.18"
 
     val CrossScalaVersions: Seq[String] = Seq(ProjectScalaVersion)
 
-    final val GlobalSbtVersion = "1.6.2"
+    final val GlobalSbtVersion = "1.11.2"
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val SbtGitHubPagesVersion = "0.15.0"
+    final val SbtGitHubPagesVersion = "0.16.0"
 
     final val CatsVersion       = "2.13.0"
-    final val CatsEffectVersion = "3.5.7"
+    final val CatsEffectVersion = "3.6.3"
 
-    final val Http4sVersion            = "0.23.30"
+    final val Http4sVersion            = "0.23.32"
     final val Http4sBlazeClientVersion = "0.23.17"
 
     final val Github4sVersion = "0.33.3"
 
     final val EffectieVersion = "2.0.0"
-    final val LoggerFVersion  = "2.1.18"
+    final val LoggerFVersion  = "2.4.0"
 
-    val LogbackVersion = "1.5.18"
+    val LogbackVersion = "1.5.19"
 
     final val JustSysprocessVersion = "1.0.0"
 
-    final val ExtrasVersion = "0.44.0"
+    final val ExtrasVersion = "0.49.0"
 
-    final val HedgehogVersion = "0.12.0"
+    final val HedgehogVersion = "0.13.0"
 
-    val CirceVersion = "0.14.12"
+    val CirceVersion = "0.14.15"
   }
 
 lazy val libs =
@@ -159,10 +153,3 @@ lazy val libs =
         tests.loggerFSlf4j,
       ) ++ tests.hedgehogLibs ++ tests.circe
   }
-
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.5")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.17.0")
 
-val sbtDevOopsVersion = "3.2.0"
+val sbtDevOopsVersion = "3.3.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % sbtDevOopsVersion)

--- a/src/main/scala/docusaur/DocusaurPlugin.scala
+++ b/src/main/scala/docusaur/DocusaurPlugin.scala
@@ -8,7 +8,6 @@ import extras.cats.syntax.either.*
 import filef.FileError2
 import githubpages.GitHubPagesPlugin
 import githubpages.GitHubPagesPlugin.autoImport as ghpg
-import loggerf.instances.cats.logF
 import loggerf.logger.*
 import sbt.Keys.streams
 import sbt.util.Logger

--- a/src/test/scala/docusaur/DocusaurSpec.scala
+++ b/src/test/scala/docusaur/DocusaurSpec.scala
@@ -14,7 +14,6 @@ import io.circe.literal.*
 import io.circe.parser.*
 import io.circe.syntax.*
 import io.circe.{Decoder, Encoder, Json}
-import loggerf.instances.cats.*
 import loggerf.logger.{CanLog, Slf4JLogger}
 
 import java.io.File


### PR DESCRIPTION
Close #221: Update dependencies and build tools, and remove Sonatype publishing configuration

- Update `sbt`: `1.9.8` -> `1.11.7`
- Update `sbt-devoops`: `3.2.0` -> `3.3.0`
- Update core dependencies:
  - `cats-effect`: `3.5.7` -> `3.6.3`
  - `http4s`: `0.23.30` -> `0.23.32`
  - `logger-f`: `2.1.18` -> `2.4.0`
  - `extras`: `0.44.0` -> `0.49.0`
  - `hedgehog`: `0.12.0` -> `0.13.0`
  - `circe`: `0.14.12` -> `0.14.15`
  - `logback`: `1.5.18` -> `1.5.19`
- Update `sbt-github-pages`: `0.15.0` -> `0.16.0`
- Remove Sonatype snapshots resolver and Maven Central publishing settings as it's not handled by sbt (1.11.7)
- Remove unused logger-f imports in `DocusaurPlugin` and `DocusaurSpec`
- Fix GitHub username casing: `Kevin-Lee` -> `kevin-lee`