### PR TITLE
cancelled release (v0.18.0)

### DIFF
--- a/changelogs/0.18.0.md
+++ b/changelogs/0.18.0.md
@@ -1,0 +1,19 @@
+## [0.18.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am24) - 2025-10-12
+
+### Internal Housekeeping
+#### Update dependencies and build tools, and remove Sonatype publishing configuration (#221)
+
+- Update `sbt`: `1.9.8` -> `1.11.7`
+- Update `sbt-devoops`: `3.2.0` -> `3.3.0`
+- Update core dependencies:
+  - `cats-effect`: `3.5.7` -> `3.6.3`
+  - `http4s`: `0.23.30` -> `0.23.32`
+  - `logger-f`: `2.1.18` -> `2.4.0`
+  - `extras`: `0.44.0` -> `0.49.0`
+  - `hedgehog`: `0.12.0` -> `0.13.0`
+  - `circe`: `0.14.12` -> `0.14.15`
+  - `logback`: `1.5.18` -> `1.5.19`
+- Update `sbt-github-pages`: `0.15.0` -> `0.16.0`
+- Remove Sonatype snapshots resolver and Maven Central publishing settings as it's not handled by sbt (1.11.7)
+- Remove unused logger-f imports in `DocusaurPlugin` and `DocusaurSpec`
+- Fix GitHub username casing: `Kevin-Lee` -> `kevin-lee`


### PR DESCRIPTION
NOTE: This release was unsuccessful. It will be done here. -> #226
# ~~sbt-docusaur v0.18.0~~
## [0.18.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am24) - 2025-10-12

### Internal Housekeeping
#### Update dependencies and build tools, and remove Sonatype publishing configuration (#221)

- Update `sbt`: `1.9.8` -> `1.11.7`
- Update `sbt-devoops`: `3.2.0` -> `3.3.0`
- Update core dependencies:
  - `cats-effect`: `3.5.7` -> `3.6.3`
  - `http4s`: `0.23.30` -> `0.23.32`
  - `logger-f`: `2.1.18` -> `2.4.0`
  - `extras`: `0.44.0` -> `0.49.0`
  - `hedgehog`: `0.12.0` -> `0.13.0`
  - `circe`: `0.14.12` -> `0.14.15`
  - `logback`: `1.5.18` -> `1.5.19`
- Update `sbt-github-pages`: `0.15.0` -> `0.16.0`
- Remove Sonatype snapshots resolver and Maven Central publishing settings as it's not handled by sbt (1.11.7)
- Remove unused logger-f imports in `DocusaurPlugin` and `DocusaurSpec`
- Fix GitHub username casing: `Kevin-Lee` -> `kevin-lee`