### PR TITLE
Update: Change npm dependency directory to /website in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/website"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Update: Change npm dependency directory to /website in Dependabot configuration