### PR TITLE
Update GitHub Actions: selectively use cache

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -27,11 +27,18 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - uses: actions/setup-node@v6
+        if: github.ref != 'refs/heads/main'
         with:
           node-version: ${{ matrix.node.version }}
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: 'website/package-lock.json'
+
+      - uses: actions/setup-node@v6
+        if: github.ref == 'refs/heads/main'
+        with:
+          node-version: ${{ matrix.node.version }}
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Build website
         env:

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           node-version: ${{ matrix.node.version }}
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
-          cache-dependency-path: 'website/package-lock.json'
 
       - name: Build and publish website
         env:


### PR DESCRIPTION
## Update GitHub Actions: selectively use cache

- Use cache for non-main build.
- Do not use cache for the main build.
- No cache for manual publish