### PR TITLE
Close #253: Update `sbt-github-pages` to `0.17.0` to support creation of the `gh-pages` branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    val SbtGitHubPagesVersion = "0.16.0"
+    val SbtGitHubPagesVersion = "0.17.0"
 
     final val CatsVersion       = "2.13.0"
     final val CatsEffectVersion = "3.6.3"


### PR DESCRIPTION
Close #253: Update `sbt-github-pages` to `0.17.0` to support creation of the `gh-pages` branch