### PR TITLE
sbt-docusaur v0.19.0

### DIFF
--- a/changelogs/0.19.0.md
+++ b/changelogs/0.19.0.md
@@ -1,0 +1,5 @@
+## [0.19.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am25) - 2025-12-30
+
+### New Features
+
+* Update `sbt-github-pages` to `0.17.0` to support creation of the `gh-pages` branch (#253)


### PR DESCRIPTION
# sbt-docusaur v0.19.0

## [0.19.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am25) - 2025-12-30

### New Features

* Update `sbt-github-pages` to `0.17.0` to support creation of the `gh-pages` branch (#253)
