### PR TITLE
Update Docusaurus to `3.10.1`, React to `^19.0.0`, and TypeScript to `~6.0.2` in `/website`

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -15,19 +15,21 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.9.2",
-    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/faster": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/tsconfig": "3.9.2",
-    "@docusaurus/types": "3.9.2",
-    "typescript": "~5.9.3"
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
+    "@types/react": "^19.0.0",
+    "typescript": "~6.0.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Update Docusaurus to `3.10.1`, React to `^19.0.0`, and TypeScript to `~6.0.2` in `/website`

Updates multiple packages and adds new dependencies in the `/website/package.json`:

* Bumps `@docusaurus/core`, `@docusaurus/preset-classic`, `@docusaurus/module-type-aliases`, `@docusaurus/tsconfig`, and `@docusaurus/types` from `3.9.2` to `3.10.1`.
* Adds `@docusaurus/faster` at version `3.10.1` to dependencies.
* Adjusts `react` and `react-dom` versions from `^19.2.4` to `^19.0.0`.
* Adds `@types/react` at version `^19.0.0` to devDependencies.
* Bumps `typescript` from `~5.9.3` to `~6.0.2`.