### PR TITLE
sbt-docusaur v0.22.0

### DIFF
--- a/changelogs/0.22.0.md
+++ b/changelogs/0.22.0.md
@@ -1,0 +1,34 @@
+## [0.22.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am28) - 2026-07-11
+
+### New Features
+
+* Support both sbt 1 and sbt 2 (#277)
+
+  `sbt-docusaur` is now cross-published for both sbt series from a single source tree.
+
+  | sbt series      | Scala   | Artifact                            |
+  |-----------------|---------|-------------------------------------|
+  | sbt 1 (1.11.2+) | 2.12.20 | `io.kevinlee:sbt-docusaur_2.12_1.0` |
+  | sbt 2 (2.0.1)   | 3.8.4   | `io.kevinlee:sbt-docusaur_sbt2_3`   |
+
+  `addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.22.0")` resolves the right one for you,
+  so no change is needed in `project/plugins.sbt`.
+
+  The minimum supported sbt 1 version is `1.11.2`.
+
+  Note that building the sbt 2 artifact requires **JDK 17** or later, because that is what the
+  Scala 3.8.4 compiler requires. Using the plugin does not.
+
+* Update `sbt-github-pages` to `0.20.0`, the release that supports both sbt 1 and sbt 2.
+
+### Internal
+
+* All tasks (`docusaurCleanNodeModules`, `docusaurInstall`, `docusaurCleanBuild`, `docusaurBuild`,
+  `docusaurAuditFix`, `docusaurGenerateAlgoliaConfigFile` and
+  `docusaurGenerateGoogleAnalyticsConfigFile`) are now marked `Def.uncached`. sbt 2 caches every
+  task by default, which would have made these npm-running / file-writing tasks no-ops on their
+  second invocation within a single session.
+
+* Removed unused dependencies: `github4s`, `http4s-dsl` and `http4s-blaze-client`.
+
+* Added unit tests (hedgehog) and scripted tests for both sbt 1 and sbt 2.


### PR DESCRIPTION
# sbt-docusaur v0.22.0
## [0.22.0](https://github.com/kevin-lee/sbt-docusaur/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am28) - 2026-07-11

### New Features

* Support both sbt 1 and sbt 2 (#277)

  `sbt-docusaur` is now cross-published for both sbt series from a single source tree.

  | sbt series      | Scala   | Artifact                            |
  |-----------------|---------|-------------------------------------|
  | sbt 1 (1.11.2+) | 2.12.20 | `io.kevinlee:sbt-docusaur_2.12_1.0` |
  | sbt 2 (2.0.1)   | 3.8.4   | `io.kevinlee:sbt-docusaur_sbt2_3`   |

  `addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.22.0")` resolves the right one for you,
  so no change is needed in `project/plugins.sbt`.

  The minimum supported sbt 1 version is `1.11.2`.

  Note that building the sbt 2 artifact requires **JDK 17** or later, because that is what the
  Scala 3.8.4 compiler requires. Using the plugin does not.

* Update `sbt-github-pages` to `0.20.0`, the release that supports both sbt 1 and sbt 2.

### Internal

* All tasks (`docusaurCleanNodeModules`, `docusaurInstall`, `docusaurCleanBuild`, `docusaurBuild`,
  `docusaurAuditFix`, `docusaurGenerateAlgoliaConfigFile` and
  `docusaurGenerateGoogleAnalyticsConfigFile`) are now marked `Def.uncached`. sbt 2 caches every
  task by default, which would have made these npm-running / file-writing tasks no-ops on their
  second invocation within a single session.

* Removed unused dependencies: `github4s`, `http4s-dsl` and `http4s-blaze-client`.

* Added unit tests (hedgehog) and scripted tests for both sbt 1 and sbt 2.
